### PR TITLE
Dyadic rationals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ VFILES:=axioms.v\
   games.v\
   neps_exp_le.v\
   numerics.v\
+  dyadic.v\
   potential.v\
   routing.v\
   routing1.v\

--- a/bigops.v
+++ b/bigops.v
@@ -133,6 +133,8 @@ Proof.
     by f_equal; rewrite rat_to_R_plus rat_to_R_opp rat_to_R_mul.
 Qed.    
 
+(*TODO: All these bigops should really be consolidated at some point...sigh*)
+
 (** Q bigops *)
 
 Delimit Scope Q_scope with Q.
@@ -158,3 +160,21 @@ Proof.
   elim: cs=> /=. rewrite Qmult_0_r. apply Qeq_refl.
     by move => a l IH; rewrite IH Qmult_plus_distr_r.
 Qed.
+
+(** N bigops *)
+
+Fixpoint big_sumN (T : Type) (cs : seq T) (f : T -> N) : N :=
+  if cs is [:: c & cs'] then (f c + big_sumN cs' f)%num
+  else 0%num.
+
+Lemma big_sumN_ext T (cs cs' : seq T) f f' :
+  cs = cs' -> f =1 f' -> big_sumN cs f = big_sumN cs' f'.
+Proof. by move=> <- H; elim: cs=> //= a l ->; f_equal; apply: H. Qed.
+
+Lemma big_sumN_scalar T (cs : seq T) r f :
+  eq (big_sumN cs (fun c => r * f c))%num (r * big_sumN cs (fun c => f c))%num.
+Proof.
+  elim: cs=> /=. rewrite N.mul_0_r. apply N.eq_refl.
+  by move => a l IH; rewrite IH Nmult_plus_distr_l.
+Qed.
+

--- a/ccombinators.v
+++ b/ccombinators.v
@@ -544,8 +544,7 @@ Proof.
   rewrite /RefineCostMaxClass /resourceCCostMaxInstance /resourceCostMaxInstance.
   apply Qle_lteq.
   right => //.
-  rewrite N_to_D_to_Q /=.
-  admit. (* HERE HERE HERE *)
+  by rewrite N_to_D_to_Q /= rat_to_Q_N_to_Q.
 Qed.
 
 Instance resource_cgame N
@@ -583,18 +582,17 @@ Extraction resources'.
 Global Instance singCCostInstance (A : Type) `(Boolable A) N
   : CCostClass N (singleton A)
   :=      
-    fun (i : OrdNat.t) (m : M.t (singleton A)) =>
-      (match M.find i m with
-            | Some t => if (boolify t) then 1%coq_Qscope else 0%coq_Qscope
-            | _ => 0%coq_Qscope
-            end).
+    (fun (i : OrdNat.t) (m : M.t (singleton A)) =>
+      match M.find i m with
+      | Some t => if boolify t then 1 else 0
+      | _ => 0
+      end)%D.
 
 Instance singCTypeInstance (A : Type) (EnumA : Enumerable A)
     : Enumerable (singleton A) := map (@Wrap Singleton A) (enumerate A).
 
 Instance singCCostMaxInstance (N : nat) (A : Type)
-    : @CCostMaxClass N (singleton A) := 1%Q.
-
+    : @CCostMaxClass N (singleton A) := 1%D.
 
 Section singletonCompilable.
   Context {A : finType} {N: nat} `{RefineTypeAxiomClass A} `{Boolable A}.
@@ -665,7 +663,7 @@ Module SingletonCGameTest. Section singletonCGameTest.
   Variable i' : OrdNat.t.
   Variable t' : M.t (singletonType A).
   Check ccost_fun (N:=N) i' t'.
-End singletonCGameTest.  End SingletonCGameTest.  
+End singletonCGameTest. End SingletonCGameTest.  
 
 (**********************************************
   Sigma games are compilable 
@@ -970,12 +968,13 @@ Instance prodCCostInstance
        `(ccostB : CCostClass N bT)
   : CCostClass N (aT*bT)
   :=
-    fun (i : OrdNat.t) (m : M.t (aT*bT)) =>
-      Qred (match M.find i m with
-            | Some (a, b) => (ccost i (map_split m).1 +
-                              ccost i (map_split m).2)%coq_Qscope
-            | _ => 0%coq_Qscope
-            end).
+    (fun (i : OrdNat.t) (m : M.t (aT*bT)) =>
+       match M.find i m with
+       | Some (a, b) =>
+         ccost i (map_split m).1 +
+         ccost i (map_split m).2
+       | _ => 0
+       end)%D.
 
 Program Instance prodRefineCostAxiomInstance
         (N : nat) (aT bT : finType)
@@ -1000,19 +999,19 @@ Next Obligation.
              (s (Ordinal (n:=N) (m:=i) pf)).2)).
   { by case: (s (Ordinal (n:=N) (m:=i) pf)). }
   move => H.
-  have H2: ((ccost) i (map_split m).1 =
+  have H2: (D_to_Q ((ccost) i (map_split m).1) ==
             rat_to_Q
-              ((cost) (Ordinal (n:=N) (m:=i) pf) [ffun j => (s j).1])).
-  { apply refineA. move => j pf'.
+              ((cost) (Ordinal (n:=N) (m:=i) pf) [ffun j => (s j).1]))%coq_Qscope.
+  { apply: refineA => j pf'.
     rewrite ffunE.
     specialize (H j pf').
     move: H. case: (s (Ordinal (n:=N) (m:=j) pf')) => a b H.
     apply map_split_spec in H.
     case: H => H0 H1.
     apply H0. }
-  have H3: ((ccost) i (map_split m).2 =
+  have H3: (D_to_Q ((ccost) i (map_split m).2) ==
             rat_to_Q
-              ((cost) (Ordinal (n:=N) (m:=i) pf) [ffun j => (s j).2])).
+              ((cost) (Ordinal (n:=N) (m:=i) pf) [ffun j => (s j).2]))%Q.
   { apply refineB. move => j pf'.
     rewrite ffunE.
     specialize (H j pf').
@@ -1021,8 +1020,9 @@ Next Obligation.
     case: H => H0 H1.
     apply H1. }
   rewrite /ccost_fun in H2, H3.
+  rewrite Dadd_ok.
   rewrite H2 H3 [rat_to_Q (_ + _)] rat_to_Q_red.
-  apply Qred_complete, Qeq_sym, rat_to_Q_plus.
+  by apply Qeq_sym; rewrite -rat_to_Q_red rat_to_Q_plus.
 Qed.
 
 Instance prodRefineCostInstance (N : nat) (aT bT : finType)
@@ -1037,7 +1037,7 @@ Instance prodRefineCostInstance (N : nat) (aT bT : finType)
 Instance prodCCostMaxInstance (N : nat) (aT bT : Type)
          (ccostMaxA : CCostMaxClass N aT)
          (ccostMaxB : CCostMaxClass N bT)
-  : CCostMaxClass N (aT*bT) := (ccostMaxA + ccostMaxB)%Q. 
+  : CCostMaxClass N (aT*bT) := (ccostMaxA + ccostMaxB)%D. 
 
 Instance prodRefineMaxCostInstance (N : nat) (aT bT : finType)
          (costMaxA   : CostMaxClass N _ aT)
@@ -1051,7 +1051,8 @@ Instance prodRefineMaxCostInstance (N : nat) (aT bT : finType)
       (prodCCostMaxInstance ccostMaxA ccostMaxB).
 Proof.
   rewrite /RefineCostMaxClass /prodCostMaxInstance /prodCCostMaxInstance
-          rat_to_Q_plus. apply Qplus_le_compat => //.
+          rat_to_Q_plus Dadd_ok.
+  by apply: Qplus_le_compat.
 Qed.
 
 Instance prod_cgame (N : nat) (aT bT : finType)
@@ -1095,11 +1096,14 @@ End prodCGameTest. End ProdCGameTest.
  *******************************************)
 
 Instance scalarEnumerableInstance
-         (A : Type) `(Enumerable A)
-         (q : rat)
+         (A : Type) (rty : realFieldType)
+         `(Enumerable A)
+         (q : rty)
   : Enumerable (scalar q A) := map (@Wrap (Scalar q) A) (enumerate A).
 
-Definition unwrapScalarTree A (q : rat) : M.t (scalar q A) -> M.t A :=
+Definition unwrapScalarTree
+           A (rty : realFieldType)
+           (q : rty) : M.t (scalar q A) -> M.t A :=
   fun m : (M.t (scalar q A)) =>
     M.fold (fun i r acc =>
               M.add i (unwrap r) acc)
@@ -1107,22 +1111,25 @@ Definition unwrapScalarTree A (q : rat) : M.t (scalar q A) -> M.t A :=
 
 Instance scalarCCostInstance
          N (A : Type)
-         `(Enumerable A) `(CCostClass N A)
-         (q : rat)
-  : CCostClass N (scalar q A)
+         `(Enumerable A)
+         `(CCostClass N A)
+         (q : DRat)
+  : CCostClass N (scalar (projT1 q) A)
   :=
-    fun (i : OrdNat.t) (m : M.t (scalar q A)) =>
-      Qred(Qmult (rat_to_Q q) (ccost i (unwrapScalarTree m))).
+    fun (i : OrdNat.t) (m : M.t (@scalar _ (projT1 q) A)) =>
+      (q * ccost i (unwrapScalarTree m))%D.
 
 Instance scalarCCostMaxInstance
-         N (A : Type) `(cmax : CCostMaxClass N A) (q : rat)
-  : @CCostMaxClass N (scalar q A) := (rat_to_Q q * cmax)%Q.
+         N (A : Type)
+         `(cmax : CCostMaxClass N A)
+         (q : DRat)
+  : @CCostMaxClass N (scalar (projT1 q) A) := (q * cmax)%D.
 
 Section scalarCompilable.
-  Context {A N} {q : rat} `{cgame N A}.
+  Context {A N} {q : DRat} `{cgame N A}.
 
   Global Program Instance scalarRefineTypeAxiomInstance
-    : @RefineTypeAxiomClass (scalarType q A) _.
+    : @RefineTypeAxiomClass (scalarType (projT1 q) A) _.
   Next Obligation.
     clear H1 H2 refineCostAxiomClass H0 refineCostClass ccostClass
           costAxiomClass costMaxAxiomClass costClass.
@@ -1137,9 +1144,13 @@ Section scalarCompilable.
     rewrite /(enumerate Wrapper Singleton A) /singCTypeInstance.
     move => r.
     apply /mapP.
-    case_eq (in_mem r (mem (enum_mem (T:=scalarType (rty:=rat_realFieldType) q A)
-              (mem (sort_of_simpl_pred (pred_of_argType
-                (Wrapper (Scalar (rty:=rat_realFieldType) q) A))))))) => H3; rewrite H3.
+    case_eq (in_mem
+               r (mem
+                  (enum_mem
+                     (T:=scalarType (rty:=rat_realFieldType) (projT1 q) A)
+                     (mem (sort_of_simpl_pred (pred_of_argType
+              (Wrapper (Scalar (rty:=rat_realFieldType) (projT1 q)) A)))))))
+      => H3; rewrite H3.
     {
       move: H3.
       case: r => x H3.
@@ -1158,11 +1169,11 @@ Section scalarCompilable.
   Qed.
 
   Global Instance scalarRefineTypeInstance
-    : @RefineTypeClass (scalarType q A)  _ _.
+    : @RefineTypeClass (scalarType (projT1 q) A)  _ _.
 
-  Lemma unwrapScalarTree_spec i (t : scalarType q A) m:
+  Lemma unwrapScalarTree_spec i (t : scalarType (projT1 q) A) m:
     M.find i m = Some t ->
-      M.find i (unwrapScalarTree m) = Some (unwrap t).
+    M.find i (unwrapScalarTree m) = Some (unwrap t).
   Proof.
     clear H H0 H1 H2 refineCostAxiomClass refineCostClass
           ccostClass costAxiomClass costMaxAxiomClass costClass.
@@ -1192,19 +1203,26 @@ Section scalarCompilable.
   Qed.
 
   Global Program Instance scalarRefineCostAxiomInstance
-    : @RefineCostAxiomClass N (scalarType q A)
-        (@scalarCostInstance _ _ _ costClass q) _. 
+    : @RefineCostAxiomClass
+        N (scalarType (projT1 q) A)
+        (@scalarCostInstance _ _ _ costClass (projT1 q))
+        _. 
   Next Obligation.
     clear H H0 H1 H2
           refineCostClass costAxiomClass.
     rewrite /cost_fun /scalarCostInstance /cost_fun.
     rewrite /(ccost) /scalarCCostInstance /(ccost).
     rewrite [rat_to_Q (_ * _)] rat_to_Q_red.
-    apply Qred_complete.
-    rewrite rat_to_Q_mul /scalar_val.
+    rewrite -rat_to_Q_red /scalar_val.
+    rewrite rat_to_Q_mul Dmult_ok.
     move: (Qeq_dec (rat_to_Q q) 0%Q).
-    case => H0;
-      first by rewrite H0 !Qmult_0_l => //.
+    case => H0.
+    { rewrite H0 !Qmult_0_l => //.
+      have ->: (D_to_Q q == 0)%Q.
+      { admit. }
+      by rewrite Qmult_0_l. }
+    have ->: (D_to_Q q == rat_to_Q (projT1 q))%Q.
+    { admit. }
     apply Qmult_inj_l => //.
     move: refineCostAxiomClass; clear refineCostAxiomClass.
     rewrite /RefineCostAxiomClass /(ccost) => refineCostAxiomClass.
@@ -1215,29 +1233,42 @@ Section scalarCompilable.
     apply unwrapScalarTree_spec in H3.
     rewrite H3. f_equal.
     rewrite /unwrap_ffun. rewrite ffunE => //.
-  Qed.
+  Admitted.
 
   Global Instance scalarRefineCostInstance
-    : @RefineCostClass N (scalarType q A)
+    : @RefineCostClass N (scalarType (projT1 q) A)
         (@scalarCostInstance N _ A costClass _) _ _.
 
-  Global Instance scalarRefineCostMaxInstance `(scalarAxiomInstance : @ScalarAxiomClass _ q)
-    : @RefineCostMaxClass N (scalarType q A)
-        (scalarCostMaxInstance costMaxClass q) (scalarCCostMaxInstance ccostMaxClass q).
+  Global Instance scalarRefineCostMaxInstance
+         `(scalarAxiomInstance : @ScalarAxiomClass _ (projT1 q))
+    : @RefineCostMaxClass
+        N (scalarType (projT1 q) A)
+        (scalarCostMaxInstance costMaxClass q)
+        (scalarCCostMaxInstance ccostMaxClass q).
   Proof.
-    rewrite /RefineCostMaxClass /scalarCostMaxInstance /scalarCCostMaxInstance 
-            rat_to_Q_mul. apply Qmult_le_l => //.
+    rewrite /RefineCostMaxClass /scalarCostMaxInstance /scalarCCostMaxInstance.
+    rewrite rat_to_Q_mul Dmult_ok.
+    rewrite /scalar_val.
+    have ->: (rat_to_Q q == D_to_Q q)%Q.
+    { admit. }
+    apply Qmult_le_l => //.
     have H3 : rat_to_Q 0 = 0%Q by rewrite rat_to_Q0.
-    rewrite -H3. apply lt_rat_to_Q => //.
-  Qed.
+    rewrite -H3.
+    have ->: (D_to_Q q == rat_to_Q (projT1 q))%Q.
+    { admit. }
+    apply lt_rat_to_Q => //.
+  Admitted.
 
-  Global Instance scalar_cgame `{scalarA : @ScalarAxiomClass rat_realFieldType q}
-    : @cgame N (scalarType q A) _ _ _ _ _ _ _ _ _ _ _ _
+  Global Instance scalar_cgame
+         `{scalarA : @ScalarAxiomClass rat_realFieldType q}
+    : @cgame
+        N (scalarType (projT1 q) A)
+        _ _ _ _ _ _ _ _ _ _ _ _
         (scalarGameInstance _ _ _ _ _).
 End scalarCompilable.
 
 Module ScalarCGameTest. Section scalarCGameTest.
-  Context {A : finType} {N : nat} `{cgame N A} {q : rat_realFieldType}
+  Context {A : finType} {N : nat} `{cgame N A} {q : DRat}
           `{scalarA : @ScalarAxiomClass rat_realFieldType q}.
   Variable i' : OrdNat.t.
   Variable t' : M.t (@scalarType rat_realFieldType q A).
@@ -1257,25 +1288,25 @@ Definition unwrapBiasTree A (q : rat) : M.t (bias q A) -> M.t A :=
 Global Instance biasCCostInstance
          N (A : Type)
          `(Enumerable A) `(CCostClass N A)
-         (q : rat)
-  : CCostClass N (bias q A)
+         (q : DRat)
+  : CCostClass N (bias (projT1 q) A)
   :=
-    fun (i : OrdNat.t) (m : M.t (bias q A)) =>
-      Qred(Qplus (rat_to_Q q) (ccost i (unwrapBiasTree m))).
+    fun (i : OrdNat.t) (m : M.t (bias (projT1 q) A)) =>
+      (q + ccost i (unwrapBiasTree m))%D.
   
-Instance biasCCostMaxInstance N (A : Type) `(cmax : CCostMaxClass N A) (q : rat)
-  : @CCostMaxClass N (bias q A) := ((rat_to_Q q) + cmax)%Q.
+Instance biasCCostMaxInstance N (A : Type) `(cmax : CCostMaxClass N A) (q : DRat)
+  : @CCostMaxClass N (bias (projT1 q) A) := (q + cmax)%D.
 
-Instance biasCTypeInstance A (q : rat)
+Instance biasCTypeInstance A (q : DRat)
          `(Enumerable A)
-  : Enumerable (bias q A) :=
-  map (@Wrap (Bias q) A) (enumerate A).
+  : Enumerable (bias (projT1 q) A) :=
+  map (@Wrap (Bias (projT1 q)) A) (enumerate A).
 
 Section biasCompilable.
-  Context {A N} {q : rat} `{cgame N A}.
+  Context {A N} {q : DRat} `{cgame N A}.
 
   Global Program Instance biasRefineTypeAxiomInstance
-    : @RefineTypeAxiomClass (biasType q A) _.
+    : @RefineTypeAxiomClass (biasType (projT1 q) A) _.
   Next Obligation.
     clear H1 H2 refineCostAxiomClass  H0 refineCostClass
           ccostClass costAxiomClass costMaxAxiomClass costClass.
@@ -1311,9 +1342,9 @@ Section biasCompilable.
   Qed.
 
   Global Instance biasRefineTypeInstance
-    : @RefineTypeClass (biasType q A)  _ _.
+    : @RefineTypeClass (biasType (projT1 q) A)  _ _.
 
-  Lemma unwrapBiasTree_spec i (t : biasType q A) m:
+  Lemma unwrapBiasTree_spec i (t : biasType (projT1 q) A) m:
     M.find i m = Some t ->
       M.find i (unwrapBiasTree m) = Some (unwrap t).
   Proof.
@@ -1345,48 +1376,56 @@ Section biasCompilable.
   Qed.
 
   Global Program Instance biasRefineCostAxiomInstance
-    : @RefineCostAxiomClass _ (biasType q A) (biasCostInstance costClass) _.
+    : @RefineCostAxiomClass _ (biasType (projT1 q) A) (biasCostInstance costClass) _.
   Next Obligation.
     clear H H0 H1 H2
           refineCostClass costAxiomClass.
     rewrite /cost_fun /biasCostInstance /cost_fun.
     rewrite /(ccost) /biasCCostInstance /ccost_fun /(ccost).
     rewrite [rat_to_Q (_ + _)] rat_to_Q_red.
-    apply Qred_complete.
+    rewrite Dadd_ok.
+    rewrite -rat_to_Q_red.
     rewrite rat_to_Q_plus /scalar_val.
+    rewrite /bias_val.
+    have ->: (D_to_Q q == rat_to_Q (projT1 q))%Q.
+    { admit. }
     move: (Qeq_dec (rat_to_Q q) 0%Q).
     move: refineCostAxiomClass; clear refineCostAxiomClass.
     rewrite /RefineCostAxiomClass /(ccost) => refineCostAxiomClass.
-    specialize (refineCostAxiomClass pf).
-    rewrite -(@refineCostAxiomClass(unwrapBiasTree m)) => //.
+    specialize (refineCostAxiomClass pf) => H.
+    rewrite ->(@refineCostAxiomClass(unwrapBiasTree m)) => //.
     move => j pf'. 
     specialize (H3 j pf').
     apply unwrapBiasTree_spec in H3.
     rewrite H3. f_equal.
     rewrite /unwrap_ffun. rewrite ffunE => //.
-  Qed.
+  Admitted.
 
   Global Instance biasRefineCostInstance
-    : @RefineCostClass N (biasType q A) (biasCostInstance costClass) _ _.
+    : @RefineCostClass N (biasType (projT1 q) A) (biasCostInstance costClass) _ _.
 
-  Global Instance biasRefineCostMaxInstance `(biasAxiomInstance : @BiasAxiomClass _ q)
-    : @RefineCostMaxClass N (biasType q A)
+  Global Instance biasRefineCostMaxInstance
+         `(biasAxiomInstance : @BiasAxiomClass _ (projT1 q))
+    : @RefineCostMaxClass N (biasType (projT1 q) A)
         (biasCostMaxInstance _ _ _ costMaxClass biasAxiomInstance)
         (biasCCostMaxInstance _ _).
   Proof.
     rewrite /RefineCostMaxClass /biasCostMaxInstance /biasCCostMaxInstance
-            rat_to_Q_plus. apply Qplus_le_compat => //.
+            rat_to_Q_plus Dadd_ok /bias_val.
+    have ->: (D_to_Q q == rat_to_Q (projT1 q))%Q.
+    { admit. }
+    apply Qplus_le_compat => //.    
     apply Qle_refl.
-  Qed.
+  Admitted.
 
   Global Instance bias_cgame `{@BiasAxiomClass rat_realFieldType q}
-    : @cgame N (biasType q A) _ _ _ _ _ _
+    : @cgame N (biasType (projT1 q) A) _ _ _ _ _ _
              (biasCostMaxAxiomInstance _ _ _ _ _ _ _ _)
              _ _ _ _ _(biasGameInstance _ _ _ _ _).
 End biasCompilable.
 
 Module BiasCGameTest. Section biasCGameTest.
-  Context {A : finType} {N : nat} `{cgame N A} {q : rat_realFieldType}
+  Context {A : finType} {N : nat} `{cgame N A} {q : DRat}
           `{biasA : @BiasAxiomClass rat_realFieldType q}.
   Variable i' : OrdNat.t.
   Variable t' : M.t (@biasType rat_realFieldType q A).
@@ -1410,28 +1449,30 @@ Section unitCompilable.
   Global Instance unitRefineTypeInstance
     : @RefineTypeClass [finType of Unit]  _ _.
 
-  Definition unit_ccost (i : OrdNat.t) (m : M.t Unit) : Qcoq :=
-    0%coq_Qscope.
+  Definition unit_ccost (i : OrdNat.t) (m : M.t Unit) : D := 0.
 
   Global Instance unitCCostInstance
     : CCostClass N [finType of Unit] := unit_ccost.
 
   Global Program Instance unitRefineCostAxiomInstance
     : @RefineCostAxiomClass N [finType of Unit] _ _.
-
+  Next Obligation.
+    rewrite /(ccost) /(cost) /unitCostInstance /unitCCostInstance /unit_ccost.
+    by rewrite D_to_Q0 rat_to_Q0.
+  Qed.
+    
   Global Instance unitRefineCostInstance
     : @RefineCostClass N [finType of Unit] _ _ _.
 
   Global Instance unitCCostMaxInstance
-    : @CCostMaxClass N [finType of Unit] := 0%Q. 
+    : @CCostMaxClass N [finType of Unit] := 0%D.
 
   Global Instance unitrefineCostMaxInstance
-    : @RefineCostMaxClass _ _ (unitCostMaxInstance N _) unitCCostMaxInstance.
+    : @RefineCostMaxClass _ _ (@unitCostMaxInstance N _) unitCCostMaxInstance.
   Proof.
     rewrite /RefineCostMaxClass /unitCostMaxInstance /unitCCostMaxInstance.
     rewrite /rat_to_Q => //.
   Qed.
 
-  Global Instance unit_cgame 
-    : cgame (N:=N) (T:= [finType of Unit]) _ _ _ _.
+  Global Instance unit_cgame : cgame (N:=N) (T:= [finType of Unit]) _ _ _ _.
 End unitCompilable.

--- a/ccombinators.v
+++ b/ccombinators.v
@@ -1219,10 +1219,10 @@ Section scalarCompilable.
     case => H0.
     { rewrite H0 !Qmult_0_l => //.
       have ->: (D_to_Q q == 0)%Q.
-      { admit. }
+      { by rewrite dyadic_rat_to_Q H0. }
       by rewrite Qmult_0_l. }
     have ->: (D_to_Q q == rat_to_Q (projT1 q))%Q.
-    { admit. }
+    { apply: dyadic_rat_to_Q. }
     apply Qmult_inj_l => //.
     move: refineCostAxiomClass; clear refineCostAxiomClass.
     rewrite /RefineCostAxiomClass /(ccost) => refineCostAxiomClass.
@@ -1233,7 +1233,7 @@ Section scalarCompilable.
     apply unwrapScalarTree_spec in H3.
     rewrite H3. f_equal.
     rewrite /unwrap_ffun. rewrite ffunE => //.
-  Admitted.
+  Qed.
 
   Global Instance scalarRefineCostInstance
     : @RefineCostClass N (scalarType (projT1 q) A)
@@ -1250,14 +1250,14 @@ Section scalarCompilable.
     rewrite rat_to_Q_mul Dmult_ok.
     rewrite /scalar_val.
     have ->: (rat_to_Q q == D_to_Q q)%Q.
-    { admit. }
+    { by rewrite dyadic_rat_to_Q. }
     apply Qmult_le_l => //.
     have H3 : rat_to_Q 0 = 0%Q by rewrite rat_to_Q0.
     rewrite -H3.
     have ->: (D_to_Q q == rat_to_Q (projT1 q))%Q.
-    { admit. }
+    { by apply: dyadic_rat_to_Q. }
     apply lt_rat_to_Q => //.
-  Admitted.
+  Qed.
 
   Global Instance scalar_cgame
          `{scalarA : @ScalarAxiomClass rat_realFieldType q}
@@ -1388,7 +1388,7 @@ Section biasCompilable.
     rewrite rat_to_Q_plus /scalar_val.
     rewrite /bias_val.
     have ->: (D_to_Q q == rat_to_Q (projT1 q))%Q.
-    { admit. }
+    { by apply: dyadic_rat_to_Q. }
     move: (Qeq_dec (rat_to_Q q) 0%Q).
     move: refineCostAxiomClass; clear refineCostAxiomClass.
     rewrite /RefineCostAxiomClass /(ccost) => refineCostAxiomClass.
@@ -1399,7 +1399,7 @@ Section biasCompilable.
     apply unwrapBiasTree_spec in H3.
     rewrite H3. f_equal.
     rewrite /unwrap_ffun. rewrite ffunE => //.
-  Admitted.
+  Qed.
 
   Global Instance biasRefineCostInstance
     : @RefineCostClass N (biasType (projT1 q) A) (biasCostInstance costClass) _ _.
@@ -1413,10 +1413,10 @@ Section biasCompilable.
     rewrite /RefineCostMaxClass /biasCostMaxInstance /biasCCostMaxInstance
             rat_to_Q_plus Dadd_ok /bias_val.
     have ->: (D_to_Q q == rat_to_Q (projT1 q))%Q.
-    { admit. }
+    { by apply: dyadic_rat_to_Q. }
     apply Qplus_le_compat => //.    
     apply Qle_refl.
-  Admitted.
+  Qed.
 
   Global Instance bias_cgame `{@BiasAxiomClass rat_realFieldType q}
     : @cgame N (biasType (projT1 q) A) _ _ _ _ _ _

--- a/ccombinators.v
+++ b/ccombinators.v
@@ -15,7 +15,7 @@ From mathcomp Require Import all_algebra.
 Import GRing.Theory Num.Def Num.Theory.
 
 Require Import strings.
-Require Import extrema dist numerics bigops.
+Require Import extrema dist numerics bigops dyadic.
 Require Import games compile smooth christodoulou combinators.
 
 Local Open Scope ring_scope.
@@ -292,11 +292,11 @@ Proof.
   by rewrite Hy addnC addn0 Qplus_leib_comm Qplus_leib_0_l.
 Qed.
 
-Definition resource_ccost N (i : OrdNat.t) (m : M.t resource) : Qcoq :=
+Definition resource_ccost N (i : OrdNat.t) (m : M.t resource) : D :=
   match M.find i m with
-  | Some RYes => N_to_Q (ctraffic N m)
-  | Some RNo => 0%coq_Qscope
-  | None => 0%coq_Qscope (*won't occur when i < N*)
+  | Some RYes => N_to_D (ctraffic N m)
+  | Some RNo => D0
+  | None => D0 (*won't occur when i < N*)
   end.
 
 Global Instance resourceCCostInstance N : CCostClass N resource
@@ -393,6 +393,10 @@ Proof.
   }
 Qed.
 
+(*FIXME: MOVE*)
+Lemma eq_Qeq q r : q=r -> Qeq q r.
+Proof. by move => ->; apply: Qeq_refl. Qed.                     
+
 Program Instance resourceRefineCostAxiomInstance N
   : @RefineCostAxiomClass N [finType of resource] _ _.
 Next Obligation.  
@@ -402,9 +406,12 @@ Next Obligation.
   case H2: (s _) => //.
   rewrite /ctraffic M.fold_1 trafficP /traffic' ctraffic_subF.
   move: (M.elements_3w m) => H1.
+  rewrite N_to_D_to_Q.
   rewrite ctraffic_sub_subP.
+  apply: eq_Qeq.
   f_equal.
-  rewrite sum1_count. rewrite -list_trafficP.
+  rewrite sum1_count.
+  rewrite -list_trafficP.
   f_equal.
   apply /perm_eqP.
   apply uniq_perm_eq.
@@ -527,15 +534,18 @@ Qed.
 Instance resourceRefineCostInstance N
   : @RefineCostClass N [finType of resource] _ _ _.
 
-Global Instance resourceCCostMaxInstance N
+Instance resourceCCostMaxInstance N
   : @CCostMaxClass N [finType of resource] :=
-      (rat_to_Q (N%:R)).
+  N_to_D (N.of_nat N).
 
 Instance resourceRefineCostMaxInstance N
   : @RefineCostMaxClass N _ (resourceCostMaxInstance _) (resourceCCostMaxInstance _).
 Proof.
-  rewrite /RefineCostMaxClass /resourceCCostMaxInstance.
-  apply Qle_lteq. right => //.
+  rewrite /RefineCostMaxClass /resourceCCostMaxInstance /resourceCostMaxInstance.
+  apply Qle_lteq.
+  right => //.
+  rewrite N_to_D_to_Q /=.
+  admit. (* HERE HERE HERE *)
 Qed.
 
 Instance resource_cgame N

--- a/combinators.v
+++ b/combinators.v
@@ -1362,29 +1362,29 @@ Definition unitType := [finType of unitTy].
 End UnitType.
 
 Instance unitCostInstance
-         (N : nat) (rty : realFieldType)
+         (N : nat) {rty : realFieldType}
   : CostClass N rty [finType of Unit] :=
   fun (i : 'I_N) (f : {ffun 'I_N -> [finType of Unit]}) => 0.
 
 Program Instance  unitCostAxiomInstance
-        (N : nat) (rty : realFieldType)
+        (N : nat) {rty : realFieldType}
   : @CostAxiomClass N rty [finType of Unit] (@unitCostInstance N rty).
 
-Instance unitCostMaxInstance ( N : nat) (rty : realFieldType)
+Instance unitCostMaxInstance ( N : nat) {rty : realFieldType}
   : CostMaxClass N rty [finType of Unit] :=
   0.
 
 Program Instance unitCostMaxAxiomInstance
-        (N : nat) (rty : realFieldType)
+        (N : nat) {rty : realFieldType}
   : CostMaxAxiomClass (@unitCostInstance N rty)
-                      (unitCostMaxInstance _ _).
+                      (@unitCostMaxInstance N rty).
 
 Program Instance unitGameInstance
-        (N : nat) (rty : realFieldType) 
+        (N : nat) {rty : realFieldType}
   : @game [finType of Unit] N rty 
           (@unitCostInstance N rty)
           (@unitCostAxiomInstance N rty) _
-          (unitCostMaxAxiomInstance _ _).
+          (@unitCostMaxAxiomInstance _ _).
 
 Module UnitGameTest. Section unitGameTest.
   Context {N rty} `{gameA : game unitType N rty}.

--- a/compile.v
+++ b/compile.v
@@ -227,34 +227,3 @@ Class Eq (A : Type) : Type :=
 
 Class Eq_Dec (A : Type) (eq : Eq A) : Type :=
   isDec : forall x y : A,  {eq x y} + {~ eq x y}.
-
-(** Dyadic real field values *)
-
-Class Iso (A B : Type) : Type :=
-  mkIso {
-      from : A -> B;
-      to : B -> A;
-      to_from : forall a, to (from a) = a;
-      from_to : forall b, from (to b) = b
-    }.
-
-Class Dyadic (rty : realFieldType) (iso : Iso rty D).
-
-Definition dyadic_rat : Type :=
-  {r : rat & {d : D & Q_to_rat (D_to_Q d) = r}}.
-
-Definition D_to_dyadic_rat (d : D) : dyadic_rat :=
-  existT _ (Q_to_rat (D_to_Q d)) (existT _ d erefl).
-
-Program Instance dyadic_rat_Iso : Iso dyadic_rat D :=
-  @mkIso _ _
-    (fun r => projT1 (projT2 r))
-    D_to_dyadic_rat
-    _ _.
-Next Obligation.
-  rewrite /D_to_dyadic_rat; case: a => //= x; case => y /= p.
-  move: (erefl (Q_to_rat (D_to_Q y))) => pf.
-  subst; f_equal.
-  f_equal.
-  apply: proof_irrelevance.
-Qed.  

--- a/compile.v
+++ b/compile.v
@@ -1,21 +1,21 @@
 Set Implicit Arguments.
 Unset Strict Implicit.
 
+Require Import ProofIrrelevance.
+Require Import QArith.
+
 Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp Require Import all_ssreflect.
 From mathcomp Require Import all_algebra.
 
 Import GRing.Theory Num.Def Num.Theory.
 
-Require Import extrema numerics games.
+Require Import extrema numerics games dyadic.
 
 (*The computable state representation is an FMap over 
   player indices, represented as positive.*)
 Require Import Coq.FSets.FMapAVL Coq.FSets.FMapFacts.
 Require Import Structures.Orders NArith.
-
-(*The computable cost function computes Q rather than rty.*)
-Require Import QArith.
 
 Module OrdNat
   <: OrderedType.OrderedType.
@@ -67,10 +67,10 @@ Class RefineTypeClass (T : finType)
 
 (** An operational type class for "compiled" cost functions, 
     from positive player indices and maps (positive -> strategy) 
-    to Q-valued costs *)
+    to D-valued costs *)
 
 Class CCostClass (N : nat) (T : Type) :=
-  ccost_fun : OrdNat.t -> M.t T -> Q.
+  ccost_fun : OrdNat.t -> M.t T -> D.
 Notation "'ccost'" := (@ccost_fun _ _) (at level 30).
 
 Class RefineCostAxiomClass N (T : finType)
@@ -82,7 +82,7 @@ Class RefineCostAxiomClass N (T : finType)
       (forall j (pf' : (nat_of_bin j < N)%nat),
           let: j' := Ordinal pf' in
           M.find j m = Some (s j')) ->
-      ccost i m = rat_to_Q (cost i' s).
+      Qeq (D_to_Q (ccost i m)) (rat_to_Q (cost i' s)).
 
 Class RefineCostClass N (T : finType)
       (costClass : CostClass N rat_realFieldType T)
@@ -90,13 +90,12 @@ Class RefineCostClass N (T : finType)
       `(@RefineCostAxiomClass N T costClass ccostClass).
 
 Class CCostMaxClass (N : nat) (T : Type) :=
-  ccostmax_fun : Q.
+  ccostmax_fun : D.
 
 Class RefineCostMaxClass (N : nat) (T : finType)
         (costMaxClass : CostMaxClass N rat_realFieldType T)
         (ccostMaxClass : CCostMaxClass N T)
-  :=
-    refineCostMax_fun : (rat_to_Q costMaxClass) <= ccostMaxClass.
+  := refineCostMax_fun : rat_to_Q costMaxClass <= D_to_Q ccostMaxClass.
 
 Lemma CCostMaxIsMax (N : nat) (T : finType)
         (costClass : CostClass N rat_realFieldType T)
@@ -112,10 +111,10 @@ Lemma CCostMaxIsMax (N : nat) (T : finType)
       (forall j (pf' : (nat_of_bin j < N)%nat),
           let: j' := Ordinal pf' in
           M.find j m = Some (s j')) ->
-          (ccost i m) <= (ccostMaxClass).
+          (ccost i m <= ccostMaxClass)%D.
 Proof.
   move => i pf m s H.
-  rewrite (refineCostAxiomClass i pf m s) => //.
+  rewrite /Dle (refineCostAxiomClass i pf m s) => //.
   apply Qle_trans with (y := rat_to_Q costMaxClass) => //.
   apply le_rat_to_Q => //.
 Qed.
@@ -135,11 +134,11 @@ Lemma CCostFinalBounds (N : nat) (T : finType)
       (forall j (pf' : (nat_of_bin j < N)%nat),
           let: j' := Ordinal pf' in
           M.find j m = Some (s j')) ->
-    0 <= (ccost i m / ccostMaxClass) <= 1.
+    0 <= (D_to_Q (ccost i m) / D_to_Q (ccostMaxClass)) <= 1.
 Proof.
   move => i pf m s H. split.
-  { have H' : 0 <= ccostMaxClass.
-    apply Qle_trans with (y := ccost i m);
+  { have H' : 0 <= D_to_Q ccostMaxClass.
+    apply Qle_trans with (y := D_to_Q (ccost i m));
       last by apply CCostMaxIsMax
         with (costClass := costClass) (costMaxClass := costMaxClass) (s := s) => //.
     rewrite (refineCostAxiomClass i pf m s) => //.
@@ -166,8 +165,8 @@ Proof.
     }
   }
   {
-    have H' : 0 <= ccostMaxClass.
-    apply Qle_trans with (y := ccost i m);
+    have H' : 0 <= D_to_Q ccostMaxClass.
+    apply Qle_trans with (y := D_to_Q (ccost i m));
       last by apply CCostMaxIsMax
         with (costClass := costClass) (costMaxClass := costMaxClass) (s := s) => //.
     rewrite (refineCostAxiomClass i pf m s) => //.
@@ -181,17 +180,7 @@ Proof.
       apply CCostMaxIsMax
         with (costClass := costClass) (costMaxClass := costMaxClass) (s := s) => //.
     }
-    {
-      rewrite -H0.
-      have H1: ccost i m == 0. apply Qle_antisym.
-      rewrite H0.
-      apply CCostMaxIsMax
-        with (costClass := costClass) (costMaxClass := costMaxClass) (s := s) => //.
-      rewrite (refineCostAxiomClass i pf m s) => //.
-      have H' : 0 = rat_to_Q 0%R. rewrite /rat_to_Q => //.
-      rewrite H'. apply le_rat_to_Q => //.
-      rewrite H1 /Qdiv /Qmult => //.
-    }
+    rewrite -H0 /Qdiv /Qinv /= Qmult_0_r //.
   }
 Qed.
 
@@ -238,3 +227,34 @@ Class Eq (A : Type) : Type :=
 
 Class Eq_Dec (A : Type) (eq : Eq A) : Type :=
   isDec : forall x y : A,  {eq x y} + {~ eq x y}.
+
+(** Dyadic real field values *)
+
+Class Iso (A B : Type) : Type :=
+  mkIso {
+      from : A -> B;
+      to : B -> A;
+      to_from : forall a, to (from a) = a;
+      from_to : forall b, from (to b) = b
+    }.
+
+Class Dyadic (rty : realFieldType) (iso : Iso rty D).
+
+Definition dyadic_rat : Type :=
+  {r : rat & {d : D & Q_to_rat (D_to_Q d) = r}}.
+
+Definition D_to_dyadic_rat (d : D) : dyadic_rat :=
+  existT _ (Q_to_rat (D_to_Q d)) (existT _ d erefl).
+
+Program Instance dyadic_rat_Iso : Iso dyadic_rat D :=
+  @mkIso _ _
+    (fun r => projT1 (projT2 r))
+    D_to_dyadic_rat
+    _ _.
+Next Obligation.
+  rewrite /D_to_dyadic_rat; case: a => //= x; case => y /= p.
+  move: (erefl (Q_to_rat (D_to_Q y))) => pf.
+  subst; f_equal.
+  f_equal.
+  apply: proof_irrelevance.
+Qed.  

--- a/dyadic.v
+++ b/dyadic.v
@@ -7,12 +7,20 @@ Record D : Set :=
 Definition pow_pos (p r : positive) : positive :=
   Pos.iter (Pos.mul p) 1%positive r.
 
+Lemma pow_pos_Zpow_pos p r : Zpos (pow_pos p r) = Z.pow_pos (Zpos p) r.
+Proof.
+  unfold pow_pos, Z.pow_pos.
+  rewrite !Pos2Nat.inj_iter; generalize (Pos.to_nat r) as n; intro.
+  revert p; induction n; auto.
+  intros p; simpl; rewrite <-IHn; auto.
+Qed.
+
 Lemma pow_pos_plus (p r s : positive) :
   pow_pos p (r + s) = (pow_pos p r * pow_pos p s)%positive.
 Admitted.
 
 Definition D_to_Q (d : D) :=
-  Qmake (num d) (pow_pos 2 (den d)).
+  Qmake (num d) (shift_pos (den d) 1).
 
 Definition Dadd (d1 d2 : D) : D :=
   match d1, d2 with
@@ -20,35 +28,120 @@ Definition Dadd (d1 d2 : D) : D :=
     if Pos.ltb y1 y2 then
       Dmake (Z.pow_pos 2 (y2 - y1) * x1 + x2) y2
     else 
-      Dmake (Z.pow_pos 2 (y1 - y2) * x1 + x2) y1
+      Dmake (Z.pow_pos 2 (y1 - y2) * x2 + x1) y1
   end.
 
 Lemma Zpower_nat_is_exp' n m z :
   Zpower_nat z (n - m) = (Zpower_nat z n / Zpower_nat z m)%Z.
 Admitted.                           
 
+Lemma Qdiv_mult (s q r : Q) : (q / r) == (q * s) / (r * s).
+Proof.
+  unfold Qdiv.
+  assert (q * s * /(r * s) = q * /r) as ->.
+  { admit. }
+  apply Qeq_refl.
+Admitted.    
+
 Lemma Dadd_ok d1 d2 :
-  D_to_Q (Dadd d1 d2) = D_to_Q d1 + D_to_Q d2.
+  D_to_Q (Dadd d1 d2) == D_to_Q d1 + D_to_Q d2.
 Proof.
   destruct d1, d2; simpl.
   generalize den0 as X; intro.
   generalize num0 as Y; intro.
   generalize den1 as Z; intro.
   generalize num1 as W; intro.
+  unfold Qplus; simpl.
+  rewrite !shift_pos_correct, Qmake_Qdiv, !Pos2Z.inj_mul, !shift_pos_correct.
+  rewrite !Zmult_1_r, !inject_Z_plus, !inject_Z_mult.
+  assert (inject_Z (Z.pow_pos 2 X) * inject_Z (Z.pow_pos 2 Z) =
+          inject_Z (Z.pow_pos 2 (X + Z))) as ->.
+  { rewrite <-inject_Z_mult.
+    symmetry; rewrite !Zpower_pos_nat.
+    rewrite Pos2Nat.inj_add, Zpower_nat_is_exp; auto. }
   destruct (Pos.ltb X Z) eqn:H.
-  { unfold D_to_Q; simpl.
-    rewrite Zpower_pos_nat.
-    rewrite nat_of_P_minus_morphism.
-    { rewrite Zpower_nat_is_exp'.
-      unfold pow_pos.
-      
-      admit. }
-    apply nat_of_P_gt_Gt_compare_complement_morphism.
-    rewrite Pos.ltb_lt in H.
-    rewrite Pos2Nat.inj_lt in H.
+  { rewrite (Qdiv_mult (1 / inject_Z (Z.pow_pos 2 X))).
+    assert (((inject_Z Y * inject_Z (Z.pow_pos 2 Z) +
+              inject_Z W * inject_Z (Z.pow_pos 2 X)) *
+             (1 / inject_Z (Z.pow_pos 2 X)) ==
+             inject_Z Y * inject_Z (Z.pow_pos 2 (Z - X)) + inject_Z W)) as ->.
+    { unfold Qdiv; rewrite Qmult_1_l.
+      rewrite Qmult_plus_distr_l.
+      unfold inject_Z.
+      rewrite <-Qmult_assoc.
+      assert ((Z.pow_pos 2 Z # 1) * / (Z.pow_pos 2 X # 1) ==
+              Z.pow_pos 2 (Z - X) # 1) as ->.
+      { admit. }        
+      apply Qplus_inj_l.
+      rewrite <-Qmult_assoc, Qmult_inv_r.
+      { rewrite Qmult_1_r; apply Qeq_refl. }
+      rewrite Zpower_pos_nat, Zpower_nat_Z.
+      unfold Qeq; simpl; rewrite Zmult_1_r; apply Z.pow_nonzero.
+      { omega. }
+      omega. }
+    assert (inject_Z (Z.pow_pos 2 (X + Z)) * (1 / inject_Z (Z.pow_pos 2 X)) ==
+            inject_Z (Z.pow_pos 2 Z)) as ->.
+    { unfold Qdiv.
+      rewrite Qmult_assoc, Qmult_comm, Qmult_assoc.
+      rewrite (Qmult_comm (/_)).
+      assert (inject_Z (Z.pow_pos 2 (X + Z)) * / inject_Z (Z.pow_pos 2 X) ==
+              inject_Z (Z.pow_pos 2 Z)) as ->.
+      { rewrite Zpower_pos_is_exp, inject_Z_mult.
+        rewrite (Qmult_comm (inject_Z (Z.pow_pos 2 X))).
+        rewrite <-Qmult_assoc, Qmult_inv_r.
+        { rewrite Qmult_1_r; apply Qeq_refl. }
+        unfold inject_Z; rewrite Zpower_pos_nat, Zpower_nat_Z.
+        unfold Qeq; simpl; rewrite Zmult_1_r; apply Z.pow_nonzero.
+        { omega. }
+        omega. }
+      rewrite Qmult_1_r; apply Qeq_refl. }
+    unfold D_to_Q; simpl.
+    rewrite <-inject_Z_mult, <-inject_Z_plus.
+    assert (Z.pow_pos 2 Z = Z.pow_pos 2 Z * ' 1)%Z as ->.
+    { rewrite Zmult_1_r; auto. }
+    rewrite <-shift_pos_correct, <-Qmake_Qdiv.
+    rewrite Zmult_comm; apply Qeq_refl; auto. }
+  rewrite (Qdiv_mult (1 / inject_Z (Z.pow_pos 2 Z))).
+  assert (((inject_Z Y * inject_Z (Z.pow_pos 2 Z) +
+            inject_Z W * inject_Z (Z.pow_pos 2 X)) *
+           (1 / inject_Z (Z.pow_pos 2 Z)) ==
+           inject_Z Y + inject_Z W * inject_Z (Z.pow_pos 2 (X - Z)))) as ->.
+  { unfold Qdiv; rewrite Qmult_1_l.
+    rewrite Qmult_plus_distr_l.
+    unfold inject_Z.
+    rewrite <-(Qmult_assoc (W # 1)).
+    assert ((Z.pow_pos 2 X # 1) * / (Z.pow_pos 2 Z # 1) ==
+            Z.pow_pos 2 (X - Z) # 1) as ->.
+    { admit. }
+    apply Qplus_inj_r.
+    rewrite <-Qmult_assoc, Qmult_inv_r.
+    { rewrite Qmult_1_r; apply Qeq_refl. }
+    rewrite Zpower_pos_nat, Zpower_nat_Z.
+    unfold Qeq; simpl; rewrite Zmult_1_r; apply Z.pow_nonzero.
+    { omega. }
     omega. }
-  admit.
-Admitted.    
+  assert (inject_Z (Z.pow_pos 2 (X + Z)) * (1 / inject_Z (Z.pow_pos 2 Z)) ==
+          inject_Z (Z.pow_pos 2 X)) as ->.
+    { unfold Qdiv.
+      rewrite Qmult_assoc, Qmult_comm, Qmult_assoc.
+      rewrite (Qmult_comm (/_)).
+      assert (inject_Z (Z.pow_pos 2 (X + Z)) * / inject_Z (Z.pow_pos 2 Z) ==
+              inject_Z (Z.pow_pos 2 X)) as ->.
+      { rewrite Zpower_pos_is_exp, inject_Z_mult.
+        rewrite <-Qmult_assoc, Qmult_inv_r.
+        { rewrite Qmult_1_r; apply Qeq_refl. }
+        unfold inject_Z; rewrite Zpower_pos_nat, Zpower_nat_Z.
+        unfold Qeq; simpl; rewrite Zmult_1_r; apply Z.pow_nonzero.
+        { omega. }
+        omega. }
+      rewrite Qmult_1_r; apply Qeq_refl. }
+  unfold D_to_Q; simpl.
+  rewrite <-inject_Z_mult, <-inject_Z_plus.
+  assert (Z.pow_pos 2 X = Z.pow_pos 2 X * ' 1)%Z as ->.
+  { rewrite Zmult_1_r; auto. }
+  rewrite <-shift_pos_correct, <-Qmake_Qdiv.
+  rewrite Zmult_comm, Z.add_comm; apply Qeq_refl.
+Admitted.
 
 Definition Dmult (d1 d2 : D) : D :=
   match d1, d2 with
@@ -56,6 +149,13 @@ Definition Dmult (d1 d2 : D) : D :=
     Dmake (x1 * x2) (y1 + y2)
   end.
 
+Lemma shift_nat1_mult n m :
+  (shift_nat n 1 * shift_nat m 1 = shift_nat n (shift_nat m 1))%positive.
+Proof.
+  induction n; simpl; auto.
+  rewrite IHn; auto.
+Qed.
+ 
 Lemma Dmult_ok d1 d2 :
   D_to_Q (Dmult d1 d2) = D_to_Q d1 * D_to_Q d2.
 Proof.
@@ -66,5 +166,6 @@ Proof.
   generalize num1 as W; intro.
   unfold D_to_Q; simpl.
   unfold Qmult; simpl.
-  rewrite pow_pos_plus; auto.
+  rewrite !shift_pos_nat, Pos2Nat.inj_add, shift_nat_plus.
+  rewrite shift_nat1_mult; auto.
 Qed.

--- a/dyadic.v
+++ b/dyadic.v
@@ -501,47 +501,51 @@ Notation "'1'" := D1 : D_scope.
 
 (** The smallest power of 2 greater than a given rational *)
 
-Definition Zlub (max : D) : Z :=
-  match max with
-  | Dmake n d => Z.log2_up (Z.div n (2 ^ Zpos d))
+Definition Zsize (z : Z) : positive :=
+  match z with
+  | Z0 => 1
+  | Zpos p => Pos.size p
+  | Zneg p => Pos.size p
   end.
 
+Definition Plub_aux (x : Z) (y : positive) : positive :=
+  Zsize x - Pos.size y.
+
+Lemma Plub_aux_ok x y : x # y <= Zpos (2^(Plub_aux x y)) # 1.
+Proof.
+Admitted.  
+
 Definition Dlub (max : D) : D :=
-  match Zlub max with
-  | Z0 => 1
-  | Zpos p => Dmake 1 p
-  | Zneg p => 0 (* can't happen *)
+  match max with
+  | Dmake x y => Dmake 1 (Plub_aux x y)
   end.
+
+Lemma Zpos_2_mult (x : Z) (y : positive) :
+  (x <= 'y)%Z -> (x * 2 <= 'y~0)%Z.
+Admitted.                   
+
+Lemma Dlub_mult_le1 d : (d * Dlub d <= 1)%D.
+Proof.
+  unfold Dle; rewrite Dmult_ok.
+  unfold D_to_Q, Qle; destruct d as [x y]; simpl.
+  rewrite Zmult_1_r.
+  assert (H: (x <= ' shift_pos (Plub_aux x y) 1)%Z).
+  { admit. }
+  eapply Zle_trans.
+Admitted.  
+
+Definition d := Dmake 1232312 2.
+Compute (d * Dlub d)%D.
 
 Local Open Scope D_scope.
 
 Lemma Dlub_nonneg (d : D) :
   0 <= d -> 0 <= Dlub d.
 Proof.
-  unfold Dlub, Dle; intros H.
-  destruct (Zlub _).
-  { unfold Qle; simpl; unfold Zle; simpl; inversion 1. }
-  { unfold Qle; simpl; unfold Zle; simpl; inversion 1. }
-  apply Qle_refl.
-Qed.  
+Admitted.
 
 Lemma Dlub_ok (d : D) :
   0 <= d -> 
   Dle 0 (d * Dlub d) /\ Dle (d * Dlub d) 1.
 Proof.
-  unfold Dle; intros H; split.
-  { rewrite D_to_Q0, Dmult_ok.
-    apply Qmult_le_0_compat; auto.
-    rewrite D_to_Q0 in H; auto.
-    rewrite <-D_to_Q0.
-    apply (Dlub_nonneg _ H). }
-  rewrite Dmult_ok.
-  unfold Dlub, D_to_Q, Qmult; simpl.
-  assert (H0 : exists p, Zlub d = Zpos p).
-  { admit. } (* TODO: Not yet used *) 
-  destruct H0 as [p H0]; rewrite H0; simpl.
-  rewrite Zmult_1_r.
-  rewrite !shift_pos_nat, !shift_nat1_mult.
-  destruct d as [x y]; simpl in *.
-  admit. (* TODO: Not yet used *) 
 Admitted. (* TODO: Not yet used *) 

--- a/dyadic.v
+++ b/dyadic.v
@@ -46,31 +46,71 @@ Proof.
   apply Qeq_refl.
 Qed.
 
-Lemma inject_Z_div x y : inject_Z (x / ' y) == inject_Z x / inject_Z (' y).
+Lemma Zdiv_pos0 (x y : positive) : (Zpos (x~0) / Zpos (y~0) = Zpos x / Zpos y)%Z.
 Proof.
-  rewrite <-Qmake_Qdiv.
-  unfold inject_Z.
-  unfold Qeq; simpl.
-Admitted. (*TODO: Not sure this is true!*)
+  rewrite Pos2Z.inj_xO, (Pos2Z.inj_xO y).
+  rewrite Zdiv_mult_cancel_l; auto.
+  inversion 1.
+Qed.  
 
-Lemma Qmult_div_lem x y : (x # 1) * / (y # 1) == (x / y) # 1.
+Lemma Zpow_pos_2exp (x y : nat) :
+  (y < x)%nat -> 
+  Z.pow 2 (Z.of_nat (x - y)) = (Z.pow 2 (Z.of_nat x) / Z.pow 2 (Z.of_nat y))%Z.
 Proof.
-  unfold Qinv.
-  destruct (Qnum _) eqn:H.
-  { simpl in H; subst y.
-    rewrite Qmult_0_r, Zdiv_0_r; apply Qeq_refl. }
-  { simpl in H|-*; subst y.
-    unfold Qmult; simpl.
-    rewrite Zmult_1_r.
-    rewrite !Qmake_Qdiv.
-    assert (inject_Z 1 = 1%Q) as ->.
-    { auto. }
-    rewrite Qdiv_1_r.
-    unfold inject_Z.
-    unfold Qdiv, Qinv, Qmult; simpl.
-    unfold Qeq; simpl.
-    rewrite 2!Zmult_1_r.
-Admitted.    
+  intros H; rewrite <-!two_power_nat_equiv; unfold two_power_nat.
+  revert y H; induction x; simpl.
+  { destruct y; try solve[inversion 1]. }
+  destruct y; simpl.
+  { intros H; rewrite Zdiv_1_r; auto. }
+  intros H.
+  rewrite IHx.
+  { rewrite Zdiv_pos0; auto. }
+  apply lt_S_n; auto.
+Qed.
+
+Lemma Pos_iter_swap' T f g (r : T) (x : positive) :
+  (forall t, f (g t) = t) -> 
+  Pos.iter f (Pos.iter g r x) x = r.
+Proof.
+  rewrite 2!Pos2Nat.inj_iter.
+  assert (H: exists y, Pos.to_nat x = Pos.to_nat y).
+  { exists x; auto. }
+  revert H; generalize (Pos.to_nat x) as n; intros n H.
+  revert r; induction n; simpl; auto.
+  intros r H2.
+  destruct (Nat.eq_dec n 0).
+  { subst n.
+    simpl.
+    rewrite H2; auto. }
+  assert (H3: exists y, n = Pos.to_nat y).
+  { exists (Pos.of_nat n).
+    rewrite Nat2Pos.id; auto. }
+  destruct H3 as [y H3].
+  subst n.
+  rewrite <-Pos2Nat.inj_iter.
+  rewrite <-Pos.iter_swap.
+  rewrite H2.
+  rewrite Pos2Nat.inj_iter.
+  apply IHn; auto.
+  exists y; auto.
+Qed.  
+
+Lemma Pos_lt_Zpos_Zlt x y :  
+  (x < y)%positive -> 
+  (' x < ' y)%Z.
+Proof.
+  unfold Z.lt; simpl; rewrite <-Pos.ltb_lt.
+  rewrite Pos.ltb_compare.
+  destruct (Pos.compare x y); auto; try solve[inversion 1].
+Qed.  
+
+Lemma Zlt_le x y : (x < y -> x <= y)%Z.
+Proof.
+  unfold Z.le; intros H.
+  generalize (Zlt_compare _ _ H).
+  destruct (Z.compare x y); try solve[inversion 1|auto].
+  intros _; inversion 1.
+Qed.
 
 Lemma Zpow_pos_div x y :
   (y < x)%positive -> 
@@ -80,11 +120,111 @@ Proof.
   assert (Zpos (x - y) = (Zpos x - Zpos y)%Z) as ->.
   { apply Pos2Z.inj_sub; auto. }
   rewrite Z.pow_sub_r; try omega.
-  rewrite Qmult_div_lem; apply Qeq_refl.
+  rewrite <-Z.pow_sub_r.
+  { unfold Qmult, Qinv; simpl.
+    assert (exists p, Z.pow_pos 2 y = Zpos p).
+    { unfold Z.pow_pos.
+      rewrite Pos2Nat.inj_iter.
+      generalize (Pos.to_nat y); induction n.
+      { simpl. exists 1%positive; auto. }
+      simpl in IHn|-*.
+      destruct IHn as [p H2]; rewrite H2; exists (p~0%positive); auto. }
+    destruct H0 as [p H1]; rewrite H1; simpl.
+    unfold Qeq; simpl; rewrite <-H1.
+    rewrite Z.pos_sub_gt; auto.
+    rewrite 2!Z.pow_pos_fold.
+    assert (2 ^ ' (x - y) * 2 ^ ' y = 2 ^ ' x)%Z as ->.
+    { assert (Zpos (x - y) = (Zpos x - Zpos y)%Z) as ->.
+      { rewrite <-Z_pos_sub_gt.
+        { rewrite <-Pos2Z.add_pos_neg.
+          unfold Z.sub; auto. }
+        rewrite Pos.gt_lt_iff; auto. }
+      assert (Hbounds : (0 <= ' y <= ' x)%Z).
+      { split.
+        { apply Pos2Z.is_nonneg. }
+        apply Zlt_le.
+        apply Pos_lt_Zpos_Zlt; auto. }
+      rewrite Z.pow_sub_r; auto; [|inversion 1].
+      rewrite <-Z.shiftr_div_pow2; [|apply Pos2Z.is_nonneg].
+      rewrite <-Z.shiftl_mul_pow2; [|apply Pos2Z.is_nonneg].
+      rewrite <-Z.shiftl_1_l.
+      rewrite Z.shiftr_shiftl_l; [|apply Pos2Z.is_nonneg].
+      rewrite Z.shiftl_shiftl.
+      { rewrite Z.sub_simpl_r; auto. }
+      destruct Hbounds.
+      apply Zle_minus_le_0; auto. }
+    rewrite 2!Zmult_1_r; auto. }
+  { inversion 1. }
+  split.
+  { apply Pos2Z.is_nonneg. }
+  unfold Zle, Z.compare; rewrite H; inversion 1. 
   split.
   { apply Pos2Z.is_nonneg. }
   unfold Zle, Z.compare; rewrite H; inversion 1. 
 Qed.
+
+Lemma Qinv_neq (n : Q) : ~0 == n -> ~0 == / n.
+Proof.
+  unfold Qeq, Qinv; simpl.
+  destruct (Qnum _); simpl; auto.
+  { intros _ H.
+    generalize (Pos2Z.is_pos (Qden n * 1)).
+    rewrite <-H; inversion 1. }
+  intros _ H.
+  generalize (Zlt_neg_0 (Qden n * 1)).
+  rewrite <-H; inversion 1.
+Qed.  
+
+Lemma Qdiv_neq_0 n m : ~n==0 -> ~m==0 -> ~(n / m == 0).
+Proof.
+  intros H H1 H2.
+  unfold Qdiv in H2.
+  apply Qmult_integral in H2; destruct H2; auto.
+  assert (H2: ~0 == m).
+  { intros H2; rewrite H2 in H1; apply H1; apply Qeq_refl. }
+  apply (Qinv_neq _ H2); rewrite H0; apply Qeq_refl.
+Qed.  
+
+Lemma Qmake_neq_0 n m : (~n=0)%Z -> ~(n # m) == 0.
+Proof.
+  intros H; unfold Qeq; simpl; intros H2.
+  rewrite Zmult_1_r in H2; subst n; apply H; auto.
+Qed.
+
+Lemma Zpow_pos_neq_0 n m : (n<>0 -> Z.pow_pos n m <> 0)%Z.
+Proof.
+  intros H0.
+  unfold Z.pow_pos.
+  apply Pos.iter_invariant.
+  { intros x H H2.
+    apply Zmult_integral in H2; destruct H2.
+    { subst; apply H0; auto. }
+    subst x; apply H; auto. }
+  inversion 1.
+Qed.
+
+Lemma Zmult_pow_plus x y r :
+  (r <> 0)%Z -> 
+  x * inject_Z (Z.pow r ('y)) / inject_Z (Z.pow r ('y+'y)) ==
+  x / inject_Z (Z.pow r ('y)).
+Proof.
+  intros H; unfold inject_Z.
+  assert (Hy: (' y >= 0)%Z).
+  { generalize (Pos2Z.is_nonneg y).
+    unfold Z.le, Z.ge; intros H2 H3.
+    destruct (Zle_compare 0 ('y)); auto. }
+  rewrite Zpower_exp; auto.
+  unfold Qdiv.
+  rewrite <-Qmult_assoc.
+  assert (r^('y) * r^('y) # 1 == (r^('y)#1) * (r^('y)#1)) as ->.
+  { unfold Qmult; simpl; apply Qeq_refl. }
+  rewrite Qinv_mult_distr.
+  rewrite (Qmult_assoc (r^('y)#1)).
+  rewrite Qmult_inv_r, Qmult_1_l.
+  { apply Qeq_refl. }
+  apply Qmake_neq_0; intros H2.
+  apply (Zpow_pos_neq_0 _ _ H H2).
+Qed.  
 
 Lemma Dadd_ok d1 d2 :
   D_to_Q (Dadd d1 d2) == D_to_Q d1 + D_to_Q d2.
@@ -146,7 +286,9 @@ Proof.
     { rewrite Zmult_1_r; auto. }
     rewrite <-shift_pos_correct, <-Qmake_Qdiv.
     rewrite Zmult_comm; apply Qeq_refl; auto.
-    admit. }
+    apply Qdiv_neq_0. { apply Q_apart_0_1. }
+    unfold inject_Z; apply Qmake_neq_0.
+    apply Zpow_pos_neq_0. inversion 1. }
   destruct (Pos.ltb Z X) eqn:H'.
   { rewrite (Qdiv_mult (1 / inject_Z (Z.pow_pos 2 Z))).
     assert (((inject_Z Y * inject_Z (Z.pow_pos 2 Z) +
@@ -190,16 +332,29 @@ Proof.
     { rewrite Zmult_1_r; auto. }
     rewrite <-shift_pos_correct, <-Qmake_Qdiv.
     rewrite Zmult_comm, Z.add_comm; apply Qeq_refl.
-    admit. }
+    apply Qdiv_neq_0. { apply Q_apart_0_1. }
+    unfold inject_Z; apply Qmake_neq_0.
+    apply Zpow_pos_neq_0. inversion 1. }
   assert (H1: X = Z).
   { generalize H'; rewrite Pos.ltb_antisym.
     generalize H; unfold Pos.ltb, Pos.leb.
     destruct (X ?= Z)%positive eqn:H2; try solve[inversion 1|inversion 2].
     intros _ _.
     apply Pos.compare_eq; auto. }
+  (* eq case *)
   subst Z; unfold D_to_Q; simpl; clear H H'.
-  admit.
-Admitted.
+  unfold Qdiv; rewrite Qmult_plus_distr_l.
+  assert (inject_Z Y * inject_Z (Z.pow_pos 2 X) *
+          / inject_Z (Z.pow_pos 2 (X + X)) ==
+          inject_Z Y / inject_Z (Z.pow_pos 2 X)) as ->.
+  { apply Zmult_pow_plus; inversion 1. }
+  assert (inject_Z W * inject_Z (Z.pow_pos 2 X) *
+          / inject_Z (Z.pow_pos 2 (X + X)) ==
+          inject_Z W / inject_Z (Z.pow_pos 2 X)) as ->.
+  { apply Zmult_pow_plus; inversion 1. }  
+  unfold Qdiv; rewrite <-Qmult_plus_distr_l, Qmake_Qdiv, inject_Z_plus.
+  unfold Qdiv; rewrite shift_pos_correct, Zmult_1_r; apply Qeq_refl.
+Qed.
 
 Definition Dmult (d1 d2 : D) : D :=
   match d1, d2 with
@@ -227,3 +382,26 @@ Proof.
   rewrite !shift_pos_nat, Pos2Nat.inj_add, shift_nat_plus.
   rewrite shift_nat1_mult; auto.
 Qed.
+
+Definition Dopp (d : D) : D :=
+  match d with
+  | Dmake x y => Dmake (-x) y
+  end.
+
+Lemma Dopp_ok d : D_to_Q (Dopp d) = Qopp (D_to_Q d).
+Proof.
+  destruct d; simpl.
+  unfold D_to_Q; simpl.
+  unfold Qopp; simpl; auto.
+Qed.
+
+Definition Dsub (d1 d2 : D) : D := Dadd d1 (Dopp d2).
+
+Lemma Dsub_ok d1 d2 :
+  D_to_Q (Dsub d1 d2) == D_to_Q d1 - D_to_Q d2.
+Proof.
+  unfold Dsub.
+  rewrite Dadd_ok.
+  rewrite Dopp_ok.
+  unfold Qminus; apply Qeq_refl.
+Qed.  

--- a/dyadic.v
+++ b/dyadic.v
@@ -15,10 +15,6 @@ Proof.
   intros p; simpl; rewrite <-IHn; auto.
 Qed.
 
-Lemma pow_pos_plus (p r s : positive) :
-  pow_pos p (r + s) = (pow_pos p r * pow_pos p s)%positive.
-Admitted.
-
 Definition D_to_Q (d : D) :=
   Qmake (num d) (shift_pos (den d) 1).
 
@@ -27,21 +23,68 @@ Definition Dadd (d1 d2 : D) : D :=
   | Dmake x1 y1, Dmake x2 y2 =>
     if Pos.ltb y1 y2 then
       Dmake (Z.pow_pos 2 (y2 - y1) * x1 + x2) y2
-    else 
-      Dmake (Z.pow_pos 2 (y1 - y2) * x2 + x1) y1
+    else if Pos.ltb y2 y1 then 
+           Dmake (Z.pow_pos 2 (y1 - y2) * x2 + x1) y1
+         else Dmake (x1 + x2) y1
   end.
 
-Lemma Zpower_nat_is_exp' n m z :
-  Zpower_nat z (n - m) = (Zpower_nat z n / Zpower_nat z m)%Z.
-Admitted.                           
-
-Lemma Qdiv_mult (s q r : Q) : (q / r) == (q * s) / (r * s).
+Lemma Qdiv_mult (s q r : Q) :
+  ~ s == 0 -> 
+  (q / r) == (q * s) / (r * s).
 Proof.
-  unfold Qdiv.
-  assert (q * s * /(r * s) = q * /r) as ->.
-  { admit. }
+  intros H; unfold Qdiv.
+  assert (q * s * /(r * s) == q * /r) as ->.
+  { rewrite Qinv_mult_distr, (Qmult_comm (/r)), Qmult_assoc.
+    rewrite <-(Qmult_assoc q), Qmult_inv_r, Qmult_1_r; auto.
+    apply Qeq_refl. }
   apply Qeq_refl.
+Qed.
+
+Lemma Qdiv_1_r q : q / 1 == q.
+Proof.
+  unfold Qdiv, Qinv; simpl; rewrite Qmult_1_r.
+  apply Qeq_refl.
+Qed.
+
+Lemma inject_Z_div x y : inject_Z (x / ' y) == inject_Z x / inject_Z (' y).
+Proof.
+  rewrite <-Qmake_Qdiv.
+  unfold inject_Z.
+  unfold Qeq; simpl.
+Admitted. (*TODO: Not sure this is true!*)
+
+Lemma Qmult_div_lem x y : (x # 1) * / (y # 1) == (x / y) # 1.
+Proof.
+  unfold Qinv.
+  destruct (Qnum _) eqn:H.
+  { simpl in H; subst y.
+    rewrite Qmult_0_r, Zdiv_0_r; apply Qeq_refl. }
+  { simpl in H|-*; subst y.
+    unfold Qmult; simpl.
+    rewrite Zmult_1_r.
+    rewrite !Qmake_Qdiv.
+    assert (inject_Z 1 = 1%Q) as ->.
+    { auto. }
+    rewrite Qdiv_1_r.
+    unfold inject_Z.
+    unfold Qdiv, Qinv, Qmult; simpl.
+    unfold Qeq; simpl.
+    rewrite 2!Zmult_1_r.
 Admitted.    
+
+Lemma Zpow_pos_div x y :
+  (y < x)%positive -> 
+  (Z.pow_pos 2 x # 1) * / (Z.pow_pos 2 y # 1) == Z.pow_pos 2 (x - y) # 1.
+Proof.
+  intros H; rewrite !Z.pow_pos_fold.
+  assert (Zpos (x - y) = (Zpos x - Zpos y)%Z) as ->.
+  { apply Pos2Z.inj_sub; auto. }
+  rewrite Z.pow_sub_r; try omega.
+  rewrite Qmult_div_lem; apply Qeq_refl.
+  split.
+  { apply Pos2Z.is_nonneg. }
+  unfold Zle, Z.compare; rewrite H; inversion 1. 
+Qed.
 
 Lemma Dadd_ok d1 d2 :
   D_to_Q (Dadd d1 d2) == D_to_Q d1 + D_to_Q d2.
@@ -71,7 +114,9 @@ Proof.
       rewrite <-Qmult_assoc.
       assert ((Z.pow_pos 2 Z # 1) * / (Z.pow_pos 2 X # 1) ==
               Z.pow_pos 2 (Z - X) # 1) as ->.
-      { admit. }        
+      { rewrite Zpow_pos_div.
+        apply Qeq_refl.
+        rewrite <-Pos.ltb_lt; auto. }
       apply Qplus_inj_l.
       rewrite <-Qmult_assoc, Qmult_inv_r.
       { rewrite Qmult_1_r; apply Qeq_refl. }
@@ -100,28 +145,32 @@ Proof.
     assert (Z.pow_pos 2 Z = Z.pow_pos 2 Z * ' 1)%Z as ->.
     { rewrite Zmult_1_r; auto. }
     rewrite <-shift_pos_correct, <-Qmake_Qdiv.
-    rewrite Zmult_comm; apply Qeq_refl; auto. }
-  rewrite (Qdiv_mult (1 / inject_Z (Z.pow_pos 2 Z))).
-  assert (((inject_Z Y * inject_Z (Z.pow_pos 2 Z) +
-            inject_Z W * inject_Z (Z.pow_pos 2 X)) *
-           (1 / inject_Z (Z.pow_pos 2 Z)) ==
-           inject_Z Y + inject_Z W * inject_Z (Z.pow_pos 2 (X - Z)))) as ->.
-  { unfold Qdiv; rewrite Qmult_1_l.
-    rewrite Qmult_plus_distr_l.
-    unfold inject_Z.
-    rewrite <-(Qmult_assoc (W # 1)).
-    assert ((Z.pow_pos 2 X # 1) * / (Z.pow_pos 2 Z # 1) ==
-            Z.pow_pos 2 (X - Z) # 1) as ->.
-    { admit. }
-    apply Qplus_inj_r.
-    rewrite <-Qmult_assoc, Qmult_inv_r.
-    { rewrite Qmult_1_r; apply Qeq_refl. }
-    rewrite Zpower_pos_nat, Zpower_nat_Z.
-    unfold Qeq; simpl; rewrite Zmult_1_r; apply Z.pow_nonzero.
-    { omega. }
-    omega. }
-  assert (inject_Z (Z.pow_pos 2 (X + Z)) * (1 / inject_Z (Z.pow_pos 2 Z)) ==
-          inject_Z (Z.pow_pos 2 X)) as ->.
+    rewrite Zmult_comm; apply Qeq_refl; auto.
+    admit. }
+  destruct (Pos.ltb Z X) eqn:H'.
+  { rewrite (Qdiv_mult (1 / inject_Z (Z.pow_pos 2 Z))).
+    assert (((inject_Z Y * inject_Z (Z.pow_pos 2 Z) +
+              inject_Z W * inject_Z (Z.pow_pos 2 X)) *
+             (1 / inject_Z (Z.pow_pos 2 Z)) ==
+             inject_Z Y + inject_Z W * inject_Z (Z.pow_pos 2 (X - Z)))) as ->.
+    { unfold Qdiv; rewrite Qmult_1_l.
+      rewrite Qmult_plus_distr_l.
+      unfold inject_Z.
+      rewrite <-(Qmult_assoc (W # 1)).
+      assert ((Z.pow_pos 2 X # 1) * / (Z.pow_pos 2 Z # 1) ==
+              Z.pow_pos 2 (X - Z) # 1) as ->.
+      { rewrite Zpow_pos_div.
+        apply Qeq_refl.
+        rewrite <-Pos.ltb_lt; auto. }
+      apply Qplus_inj_r.
+      rewrite <-Qmult_assoc, Qmult_inv_r.
+      { rewrite Qmult_1_r; apply Qeq_refl. }
+      rewrite Zpower_pos_nat, Zpower_nat_Z.
+      unfold Qeq; simpl; rewrite Zmult_1_r; apply Z.pow_nonzero.
+      { omega. }
+      omega. }
+    assert (inject_Z (Z.pow_pos 2 (X + Z)) * (1 / inject_Z (Z.pow_pos 2 Z)) ==
+            inject_Z (Z.pow_pos 2 X)) as ->.
     { unfold Qdiv.
       rewrite Qmult_assoc, Qmult_comm, Qmult_assoc.
       rewrite (Qmult_comm (/_)).
@@ -135,12 +184,21 @@ Proof.
         { omega. }
         omega. }
       rewrite Qmult_1_r; apply Qeq_refl. }
-  unfold D_to_Q; simpl.
-  rewrite <-inject_Z_mult, <-inject_Z_plus.
-  assert (Z.pow_pos 2 X = Z.pow_pos 2 X * ' 1)%Z as ->.
-  { rewrite Zmult_1_r; auto. }
-  rewrite <-shift_pos_correct, <-Qmake_Qdiv.
-  rewrite Zmult_comm, Z.add_comm; apply Qeq_refl.
+    unfold D_to_Q; simpl.
+    rewrite <-inject_Z_mult, <-inject_Z_plus.
+    assert (Z.pow_pos 2 X = Z.pow_pos 2 X * ' 1)%Z as ->.
+    { rewrite Zmult_1_r; auto. }
+    rewrite <-shift_pos_correct, <-Qmake_Qdiv.
+    rewrite Zmult_comm, Z.add_comm; apply Qeq_refl.
+    admit. }
+  assert (H1: X = Z).
+  { generalize H'; rewrite Pos.ltb_antisym.
+    generalize H; unfold Pos.ltb, Pos.leb.
+    destruct (X ?= Z)%positive eqn:H2; try solve[inversion 1|inversion 2].
+    intros _ _.
+    apply Pos.compare_eq; auto. }
+  subst Z; unfold D_to_Q; simpl; clear H H'.
+  admit.
 Admitted.
 
 Definition Dmult (d1 d2 : D) : D :=

--- a/dyadic.v
+++ b/dyadic.v
@@ -1,4 +1,4 @@
-Require Import ZArith PArith QArith.
+Require Import ZArith PArith QArith ProofIrrelevance.
 
 Record D : Set :=
   Dmake { num : Z;
@@ -495,3 +495,6 @@ Infix "+" := Dadd : D_scope.
 Notation "- x" := (Dopp x) : D_scope.
 Infix "-" := Dsub : D_scope.
 Infix "*" := Dmult : D_scope.
+
+Notation "'0'" := D0 : D_scope.
+Notation "'1'" := D1 : D_scope.

--- a/dyadic.v
+++ b/dyadic.v
@@ -1,0 +1,70 @@
+Require Import ZArith PArith QArith.
+
+Record D : Set :=
+  Dmake { num : Z;
+          den : positive }.
+
+Definition pow_pos (p r : positive) : positive :=
+  Pos.iter (Pos.mul p) 1%positive r.
+
+Lemma pow_pos_plus (p r s : positive) :
+  pow_pos p (r + s) = (pow_pos p r * pow_pos p s)%positive.
+Admitted.
+
+Definition D_to_Q (d : D) :=
+  Qmake (num d) (pow_pos 2 (den d)).
+
+Definition Dadd (d1 d2 : D) : D :=
+  match d1, d2 with
+  | Dmake x1 y1, Dmake x2 y2 =>
+    if Pos.ltb y1 y2 then
+      Dmake (Z.pow_pos 2 (y2 - y1) * x1 + x2) y2
+    else 
+      Dmake (Z.pow_pos 2 (y1 - y2) * x1 + x2) y1
+  end.
+
+Lemma Zpower_nat_is_exp' n m z :
+  Zpower_nat z (n - m) = (Zpower_nat z n / Zpower_nat z m)%Z.
+Admitted.                           
+
+Lemma Dadd_ok d1 d2 :
+  D_to_Q (Dadd d1 d2) = D_to_Q d1 + D_to_Q d2.
+Proof.
+  destruct d1, d2; simpl.
+  generalize den0 as X; intro.
+  generalize num0 as Y; intro.
+  generalize den1 as Z; intro.
+  generalize num1 as W; intro.
+  destruct (Pos.ltb X Z) eqn:H.
+  { unfold D_to_Q; simpl.
+    rewrite Zpower_pos_nat.
+    rewrite nat_of_P_minus_morphism.
+    { rewrite Zpower_nat_is_exp'.
+      unfold pow_pos.
+      
+      admit. }
+    apply nat_of_P_gt_Gt_compare_complement_morphism.
+    rewrite Pos.ltb_lt in H.
+    rewrite Pos2Nat.inj_lt in H.
+    omega. }
+  admit.
+Admitted.    
+
+Definition Dmult (d1 d2 : D) : D :=
+  match d1, d2 with
+  | Dmake x1 y1, Dmake x2 y2 =>
+    Dmake (x1 * x2) (y1 + y2)
+  end.
+
+Lemma Dmult_ok d1 d2 :
+  D_to_Q (Dmult d1 d2) = D_to_Q d1 * D_to_Q d2.
+Proof.
+  destruct d1, d2; simpl.
+  generalize den0 as X; intro.
+  generalize num0 as Y; intro.
+  generalize den1 as Z; intro.
+  generalize num1 as W; intro.
+  unfold D_to_Q; simpl.
+  unfold Qmult; simpl.
+  rewrite pow_pos_plus; auto.
+Qed.

--- a/dyadic.v
+++ b/dyadic.v
@@ -498,3 +498,50 @@ Infix "*" := Dmult : D_scope.
 
 Notation "'0'" := D0 : D_scope.
 Notation "'1'" := D1 : D_scope.
+
+(** The smallest power of 2 greater than a given rational *)
+
+Definition Zlub (max : D) : Z :=
+  match max with
+  | Dmake n d => Z.log2_up (Z.div n (2 ^ Zpos d))
+  end.
+
+Definition Dlub (max : D) : D :=
+  match Zlub max with
+  | Z0 => 1
+  | Zpos p => Dmake 1 p
+  | Zneg p => 0 (* can't happen *)
+  end.
+
+Local Open Scope D_scope.
+
+Lemma Dlub_nonneg (d : D) :
+  0 <= d -> 0 <= Dlub d.
+Proof.
+  unfold Dlub, Dle; intros H.
+  destruct (Zlub _).
+  { unfold Qle; simpl; unfold Zle; simpl; inversion 1. }
+  { unfold Qle; simpl; unfold Zle; simpl; inversion 1. }
+  apply Qle_refl.
+Qed.  
+
+Lemma Dlub_ok (d : D) :
+  0 <= d -> 
+  Dle 0 (d * Dlub d) /\ Dle (d * Dlub d) 1.
+Proof.
+  unfold Dle; intros H; split.
+  { rewrite D_to_Q0, Dmult_ok.
+    apply Qmult_le_0_compat; auto.
+    rewrite D_to_Q0 in H; auto.
+    rewrite <-D_to_Q0.
+    apply (Dlub_nonneg _ H). }
+  rewrite Dmult_ok.
+  unfold Dlub, D_to_Q, Qmult; simpl.
+  assert (H0 : exists p, Zlub d = Zpos p).
+  { admit. } (* TODO: Not yet used *) 
+  destruct H0 as [p H0]; rewrite H0; simpl.
+  rewrite Zmult_1_r.
+  rewrite !shift_pos_nat, !shift_nat1_mult.
+  destruct d as [x y]; simpl in *.
+  admit. (* TODO: Not yet used *) 
+Admitted. (* TODO: Not yet used *) 

--- a/dyadic.v
+++ b/dyadic.v
@@ -480,3 +480,18 @@ Fixpoint g (n : nat) (q : Q) : Q :=
 Time Compute g 5000 (Qmake 3 2).
 (*Finished transaction in 0.847 secs (0.848u,0.s) (successful)*)
 (*Speedup on this microbenchmark: 70x*)*)
+
+Delimit Scope D_scope with D.
+Bind Scope D_scope with D.
+Arguments Dmake _%Z _%positive.
+
+Infix "<" := Dlt : D_scope.
+Infix "<=" := Dle : D_scope.
+Notation "x > y" := (Dlt y x)(only parsing) : D_scope.
+Notation "x >= y" := (Dle y x)(only parsing) : D_scope.
+Notation "x <= y <= z" := (x<=y/\y<=z) : D_scope.
+
+Infix "+" := Dadd : D_scope.
+Notation "- x" := (Dopp x) : D_scope.
+Infix "-" := Dsub : D_scope.
+Infix "*" := Dmult : D_scope.

--- a/loadbalancing.v
+++ b/loadbalancing.v
@@ -167,23 +167,11 @@ Definition num_players' : nat :=
 Definition num_iters : N.t := 60.
 Definition eps : D := Dmake 1 2. (*eps = 1/4*)
 
-Definition Zupper_bound (max : D) : Z :=
-  match max with
-  | Dmake n d => Z.log2_up (Z.div n (2 ^ Zpos d))
-  end.
-
-Definition Dupper_bound (max : D) : D :=
-  match Zupper_bound max with
-  | Z0 => 0 (* can't happen *)
-  | Zpos p => Dmake 1 p
-  | Zneg p => 0 (* can't happen *)
-  end.
-
 Module RAffine3Scalar <: OrderedScalarType.
   Include RAffine3.
   Definition scal :=
     D_to_dyadic_rat
-      (Dupper_bound
+      (Dlub
          (@ccostmax_fun num_players' RAffine3.t
                         (RAffine3.cost_max num_players'))).
 End RAffine3Scalar.

--- a/numerics.v
+++ b/numerics.v
@@ -1515,21 +1515,17 @@ Proof.
   rewrite natrD rat_to_Q_plus IH //.
 Qed.
 
+Lemma Qred_idem (q : Q) : Qred (Qred q) = Qred q.
+Proof.
+  apply: Qred_complete.
+  by rewrite Qred_correct.
+Qed.  
+
 (** Dyadic real field values *)
 
-Class Iso (A B : Type) : Type :=
-  mkIso {
-      from : A -> B;
-      to : B -> A;
-      to_from : forall a, to (from a) = a;
-      from_to : forall b, from (to b) = b
-    }.
-
-Class Dyadic (rty : realFieldType) (iso : Iso rty D).
-
 Definition dyadic_rat : Type :=
-  {r : rat & {d : D & Q_to_rat (D_to_Q d) = r}}.
-Notation "'DRat'" := dyadic_rat.
+  {r : rat & {d : D & Qeq (D_to_Q d) (rat_to_Q r)}}.
+Notation "'DRat'" := (dyadic_rat) (only parsing).
 
 Definition dyadic_rat_to_rat (d : dyadic_rat) : rat := projT1 d.
 Coercion dyadic_rat_to_rat : dyadic_rat >-> rat.
@@ -1537,18 +1533,13 @@ Coercion dyadic_rat_to_rat : dyadic_rat >-> rat.
 Definition dyadic_rat_to_D (d : dyadic_rat) : D := projT1 (projT2 d).
 Coercion dyadic_rat_to_D : dyadic_rat >-> D.
 
-Definition D_to_dyadic_rat (d : D) : dyadic_rat :=
-  existT _ (Q_to_rat (D_to_Q d)) (existT _ d erefl).
-
-Program Instance dyadic_rat_Iso : Iso dyadic_rat D :=
-  @mkIso _ _
-    dyadic_rat_to_D
-    D_to_dyadic_rat
-    _ _.
+Program Definition D_to_dyadic_rat (d : D) : DRat :=
+  existT _ (Q_to_rat (D_to_Q d)) _.
 Next Obligation.
-  rewrite /D_to_dyadic_rat; case: a => //= x; case => y /= p.
-  move: (erefl (Q_to_rat (D_to_Q y))) => pf.
-  subst; f_equal.
-  f_equal.
-  apply: proof_irrelevance.
-Qed.  
+  exists d.
+  rewrite rat_to_QK1.
+  by rewrite Qred_correct.
+Defined.
+
+Lemma dyadic_rat_to_Q (d : DRat) : Qeq (D_to_Q d) (rat_to_Q d).
+Proof. apply: (projT2 (projT2 d)). Qed.

--- a/numerics.v
+++ b/numerics.v
@@ -9,6 +9,8 @@ From mathcomp Require Import all_algebra.
 
 Import GRing.Theory Num.Def Num.Theory.
 
+Require Import dyadic.
+
 (** This file defines conversions between Ssreflect/MathComp and
     Coq Standard Library implementations of various numeric types, 
     such as: 
@@ -1100,7 +1102,7 @@ Section Q_to_rat_lemmas.
     rewrite invr_gt0.
       by rewrite -ltz_nat -(ltr_int rat_realFieldType) in H2.
   Qed.
-
+  
   Lemma Q_to_rat_opp r :
     Q_to_rat (Qopp r) = (- (Q_to_rat r))%R.
   Proof.
@@ -1475,3 +1477,25 @@ Proof.
   by rewrite Pos2Z.inj_add /Qplus /= !Pos.mul_1_r.
 Qed.
 
+Definition N_to_D (n : N.t) : D := Dmake (2*NtoZ n) 1.
+
+Lemma N_to_D_plus n1 n2 :
+  (N_to_D (n1 + n2) = N_to_D n1 + N_to_D n2)%D.
+Proof.
+  rewrite /N_to_D /NtoZ /Nplus.
+  case: n1; case: n2 => //.
+Qed.
+
+Lemma N_to_D_to_Q n : Qeq (D_to_Q (N_to_D n)) (N_to_Q n).
+Proof.
+  rewrite /D_to_Q /N_to_D /N_to_Q /=.
+  case H: (NtoZ n) => [|p|p].
+  { by rewrite /Qeq. }
+  { rewrite /Qeq /=.
+    rewrite Pos.mul_1_r.
+    rewrite Pos2Z.inj_xO /Zmult.
+    by rewrite Pos.mul_comm. }
+  by rewrite /Qeq /= Pos.mul_1_r Pos2Z.neg_xO /Zmult Pos.mul_comm.
+Qed.  
+    
+              

--- a/orderedtypes.v
+++ b/orderedtypes.v
@@ -158,7 +158,6 @@ Module OrderedSingleton (A : BoolableMyOrderedType) <: BoolableMyOrderedType.
   Definition t0 := Wrap Singleton A.t0.
   Definition enumerable := (singCTypeInstance A.enumerable).
   Definition cost_instance N := singCCostInstance (A.boolable) N.
-  Print singCCostMaxInstance.
   Definition cost_max N := @singCCostMaxInstance N A.t.
   Definition show_sing (sA : singleton (A.t)) : string := 
       append "Singleton" (to_string (unwrap sA)).
@@ -412,12 +411,12 @@ End OrderedFinSigma.
 
 Module Type OrderedScalarType.
   Include MyOrderedType.
-  Parameter scal : DRat.
+  Parameter scal : dyadic_rat.
 End OrderedScalarType.
 
 Module Type BoolableOrderedScalarType.
   Include BoolableMyOrderedType.
-  Parameter scal : DRat.
+  Parameter scal : dyadic_rat.
 End BoolableOrderedScalarType.
                       
 Module OrderedScalar (T : OrderedScalarType) <: MyOrderedType.
@@ -475,7 +474,7 @@ End OrderedOffsetSingletonComponent.
   
 Module Type OrderedBiasType.
   Include MyOrderedType.
-  Parameter bias : DRat.
+  Parameter bias : dyadic_rat.
 End OrderedBiasType.
                       
 Module OrderedBias (T : OrderedBiasType) <: MyOrderedType.
@@ -520,8 +519,8 @@ End OrderedBias.
 
 Module Type OrderedAffineType.
   Include BoolableMyOrderedType.
-  Parameter scal : DRat.
-  Parameter offset : DRat.
+  Parameter scal : dyadic_rat.
+  Parameter offset : dyadic_rat.
   (* why the a0? *)
   Parameter a0 : t.
 End OrderedAffineType.

--- a/orderedtypes.v
+++ b/orderedtypes.v
@@ -8,7 +8,7 @@ Require Import QArith.
 Require Import Coq.FSets.FMapFacts.
 Require Import Structures.Orders NArith.
 
-Require Import strings compile combinators ccombinators.
+Require Import strings compile combinators ccombinators numerics dyadic.
 
 Module Type MyOrderedType.
   Parameter t : Type.
@@ -412,19 +412,19 @@ End OrderedFinSigma.
 
 Module Type OrderedScalarType.
   Include MyOrderedType.
-  Parameter scal : rat.
+  Parameter scal : DRat.
 End OrderedScalarType.
 
 Module Type BoolableOrderedScalarType.
   Include BoolableMyOrderedType.
-  Parameter scal : rat.
+  Parameter scal : DRat.
 End BoolableOrderedScalarType.
                       
 Module OrderedScalar (T : OrderedScalarType) <: MyOrderedType.
-  Definition t := scalar T.scal T.t.
+  Definition t := scalar (projT1 T.scal) T.t.
   Definition t0 := Wrap (Scalar (rty:=rat_realFieldType) T.scal) T.t0.
   Definition enumerable : Enumerable t :=
-    scalarEnumerableInstance T.enumerable T.scal.
+    scalarEnumerableInstance T.enumerable (projT1 T.scal).
   Definition cost_instance (N : nat) :=
     scalarCCostInstance T.enumerable (T.cost_instance N) (q:=T.scal).
   Definition cost_max (N : nat) :=
@@ -475,11 +475,11 @@ End OrderedOffsetSingletonComponent.
   
 Module Type OrderedBiasType.
   Include MyOrderedType.
-  Parameter bias : rat.
+  Parameter bias : DRat.
 End OrderedBiasType.
                       
 Module OrderedBias (T : OrderedBiasType) <: MyOrderedType.
-  Definition t := bias T.bias T.t.
+  Definition t := bias (projT1 T.bias) T.t.
   Definition t0 := Wrap (Bias (rty:=rat_realFieldType) T.bias) T.t0.
   Definition enumerable : Enumerable t :=
     biasCTypeInstance T.bias T.enumerable.
@@ -520,8 +520,8 @@ End OrderedBias.
 
 Module Type OrderedAffineType.
   Include BoolableMyOrderedType.
-  Parameter scal : rat.
-  Parameter offset : rat.
+  Parameter scal : DRat.
+  Parameter offset : DRat.
   (* why the a0? *)
   Parameter a0 : t.
 End OrderedAffineType.

--- a/routing.v
+++ b/routing.v
@@ -379,23 +379,11 @@ End T.
 
 Definition num_players : nat := 10.
 
-Definition Zupper_bound (max : D) : Z :=
-  match max with
-  | Dmake n d => Z.log2_up (Z.div n (2 ^ Zpos d))
-  end.
-
-Definition Dupper_bound (max : D) : D :=
-  match Zupper_bound max with
-  | Z0 => 0 (* can't happen *)
-  | Zpos p => Dmake 1 p
-  | Zneg p => 0 (* can't happen *)
-  end.
-
 Module P8Scalar <: OrderedScalarType.
   Include P8.
   Definition scal :=
     D_to_dyadic_rat
-      (Dupper_bound
+      (Dlub
          (@ccostmax_fun num_players P8.t (P8.cost_max num_players))).
 End P8Scalar.
 

--- a/routing1.v
+++ b/routing1.v
@@ -379,23 +379,11 @@ Definition num_players : nat := 15.
 Definition num_iters : N.t := 100.
 Definition eps : D := Dmake 1 3. (*eps = 1/8*)
 
-Definition Zupper_bound (max : D) : Z :=
-  match max with
-  | Dmake n d => Z.log2_up (Z.div n (2 ^ Zpos d))
-  end.
-
-Definition Dupper_bound (max : D) : D :=
-  match Zupper_bound max with
-  | Z0 => 0 (* can't happen *)
-  | Zpos p => Dmake 1 p
-  | Zneg p => 0 (* can't happen *)
-  end.
-
 Module P3Scalar <: OrderedScalarType.
   Include P3.
   Definition scal :=
     D_to_dyadic_rat
-      (Dupper_bound (@ccostmax_fun num_players P3.t (P3.cost_max num_players))).
+      (Dlub (@ccostmax_fun num_players P3.t (P3.cost_max num_players))).
 End P3Scalar.
 
 Module P3Scaled <: MyOrderedType := OrderedScalar P3Scalar.

--- a/routing1.v
+++ b/routing1.v
@@ -12,7 +12,7 @@ From mathcomp Require Import all_ssreflect.
 From mathcomp Require Import all_algebra.
 Import GRing.Theory Num.Def Num.Theory.
 
-Require Import numerics combinators games compile orderedtypes.
+Require Import numerics combinators games compile orderedtypes dyadic.
 Require Import weightsextract server.
 
 Local Open Scope ring_scope.
@@ -147,7 +147,7 @@ Unset Strict Implicit.
   
 (*MOVE:*)
 Instance UnitCCostMaxClass (N : nat) 
-  : CCostMaxClass N Unit := Qmake 0 1.
+  : CCostMaxClass N Unit := 0%D.
 Instance UnitBoolableInstance : Boolable Unit :=
   fun _ => false.
 Instance UnitEq : Eq Unit := fun x y => True.
@@ -200,16 +200,16 @@ Module R <: BoolableMyOrderedType := OrderedResource.
 
 Module R10Values <: OrderedAffineType.
   Include R.                    
-  Definition scal := Q_to_rat (Qmake 10 1).
-  Definition offset := Q_to_rat (Qmake 0 1).
+  Definition scal := D_to_dyadic_rat (Dmake 20 1).
+  Definition offset := D_to_dyadic_rat 0.
   Definition a0 := RNo.
 End R10Values.
 Module R10 := OrderedAffine R10Values.
 
 Module RValues <: OrderedAffineType.
   Include R.                    
-  Definition scal := Q_to_rat (Qmake 1 1).
-  Definition offset := Q_to_rat (Qmake 0 1).
+  Definition scal := D_to_dyadic_rat 1.
+  Definition offset := D_to_dyadic_rat 0.
   Definition a0 := RNo.
 End RValues.
 Module R' := OrderedAffine RValues.
@@ -376,14 +376,26 @@ end.
 End T.
   
 Definition num_players : nat := 15.
-Definition num_iters : N.t := 30.
-Definition eps : Q := Qmake 1 2.
+Definition num_iters : N.t := 100.
+Definition eps : D := Dmake 1 3. (*eps = 1/8*)
+
+Definition Zupper_bound (max : D) : Z :=
+  match max with
+  | Dmake n d => Z.log2_up (Z.div n (2 ^ Zpos d))
+  end.
+
+Definition Dupper_bound (max : D) : D :=
+  match Zupper_bound max with
+  | Z0 => 0 (* can't happen *)
+  | Zpos p => Dmake 1 p
+  | Zneg p => 0 (* can't happen *)
+  end.
 
 Module P3Scalar <: OrderedScalarType.
   Include P3.
   Definition scal :=
-    Q_to_rat
-      (Qdiv 1 (@ccostmax_fun num_players P3.t (P3.cost_max num_players))).
+    D_to_dyadic_rat
+      (Dupper_bound (@ccostmax_fun num_players P3.t (P3.cost_max num_players))).
 End P3Scalar.
 
 Module P3Scaled <: MyOrderedType := OrderedScalar P3Scalar.
@@ -419,7 +431,7 @@ Module MWU := MWU P3Scaled'.
 Existing Instance P3Scaled'.enumerable.
 
 (*Why doesn' Coq discover this instance in the following definition?*)
-Definition mwu0 (eps : Q) (nx : N.t)
+Definition mwu0 (eps : D) (nx : N.t)
            {T chanty : Type} {oracle : ClientOracle T chanty}
            (init_oracle_st : T) :=
   MWU.interp

--- a/server.v
+++ b/server.v
@@ -8,7 +8,7 @@ Require Import QArith String Ascii.
 Require Import Coq.FSets.FMapAVL Coq.FSets.FMapFacts.
 Require Import Structures.Orders NArith.
 
-Require Import strings compile orderedtypes.
+Require Import strings compile orderedtypes dyadic numerics.
 
 Module Type ServerConfig.
   Parameter num_players : nat.
@@ -22,7 +22,7 @@ Class ServerOracle T oracle_chanty :=
            ; oracle_send : forall A : Type,
                T -> option oracle_chanty ->
                nat (*player index*) ->
-               list (A * Q) -> T
+               list (A * D) -> T
            }.
 
 Module Server (C : ServerConfig) (A : MyOrderedType).  
@@ -48,13 +48,13 @@ Module Server (C : ServerConfig) (A : MyOrderedType).
             nil
             st.
 
-  Definition cost_vector (s : state) (player : N) : list (A.t * Q) :=
+  Definition cost_vector (s : state) (player : N) : list (A.t * D) :=
     List.fold_left
       (fun l a => (a, ccost player (M.add player a (actions_received s))) :: l)
       (enumerate A.t)
       nil.
 
-  Fixpoint compute_social_cost (s : state) (player : nat) : Q :=
+  Fixpoint compute_social_cost (s : state) (player : nat) : D :=
   match player with
   | O => ccost (N.of_nat player) (actions_received s)
   | S n' => ccost (N.of_nat player) (actions_received s) +
@@ -63,7 +63,7 @@ Module Server (C : ServerConfig) (A : MyOrderedType).
 
   Definition print_social_cost (s : state) : state :=
     let s' := eprint_string "Social cost: " s in
-    let s'' := eprint_Q (compute_social_cost s (C.num_players)) s' in
+    let s'' := eprint_Q (D_to_Q (compute_social_cost s (C.num_players))) s' in
     eprint_newline s''.
 
   Fixpoint send (s : state) (player : nat) : state :=
@@ -156,7 +156,7 @@ Extract Constant server_recv =>
 
 (* Server send *)
 Axiom server_send :
-  forall A : Type, result -> option chan -> nat (*player index*) -> list (A * Q) -> result.
+  forall A : Type, result -> option chan -> nat (*player index*) -> list (A * D) -> result.
 Extract Constant server_send =>
 (* Here it is taking service_socket as an argument which is assumed to *)
 (*    be the socket created in recv that corresponds to player i *)

--- a/weightsextract.v
+++ b/weightsextract.v
@@ -588,10 +588,10 @@ Module MWUProof (T : OrderedFinType).
         rewrite (rat_to_QK2 (r:=s a)) => //.
         by rewrite -(Qred_correct (D_to_Q q)) H2. }
       rewrite rat_to_Q_plus 2!rat_to_QK1.
-      admit. }
+      by rewrite 2!Qred_correct. }
     move => ax qx H2.
     by apply: (H _ _ (or_intror H2)).
-  Admitted.
+  Qed.
 
   Lemma InA_notin a (l : seq t) : ~InA A.eq a l -> a \notin l.
   Proof.
@@ -991,8 +991,9 @@ Module MWUProof (T : OrderedFinType).
     exists q; split => //.
     apply: Hmatch => //.
     rewrite /Dlt in H5.
-    admit.
-  Admitted.
+    clear - H5. move: H5.
+    by rewrite D_to_Q0.
+  Qed.
   
   Lemma match_maps_update_weights (f : t -> expr t) r s m :
     match_states r s ->
@@ -1067,11 +1068,15 @@ Module MWUProof (T : OrderedFinType).
         { rewrite -Q_to_rat0; apply: Q_to_rat_le.
           have H4: (Qeq (Qred (D_to_Q q))) (D_to_Q q) by apply: Qred_correct.
           rewrite H4.
-          admit.
+          clear - H; move: H.
+          rewrite /Dle_bool D_to_Q0 => H.
+          by apply: (Qle_bool_imp_le _ _ H).
         }
         rewrite -Q_to_rat1; apply: Q_to_rat_le.
         move: (Qred_correct (D_to_Q q)) ->.
-        admit. }
+        clear - H3; move: H3.
+        rewrite /Dle_bool D_to_Q1 => H3.
+        by apply: (Qle_bool_imp_le _ _ H3). }
       exists CSkip.
       have Hora: match_oracle_states (weightslang.SOracleSt s) (SOracleSt tx).
       { by case: H2. }
@@ -1297,7 +1302,7 @@ Module MWUProof (T : OrderedFinType).
       apply: H12.
       apply: H13. }
     inversion 1.
-  Admitted.
+  Qed.
 
   Lemma findA_map1_Some1 a (l : list t) :
     a \in l ->
@@ -1360,10 +1365,10 @@ Module MWUProof (T : OrderedFinType).
     { constructor. }
     { apply: match_maps_init. }
     { rewrite rat_to_Q_red rat_to_QK1.
-      admit. (*need Qred (Qred q) = Qred q*) }
+      by rewrite Qred_idem. }
     { constructor. }
     apply: Hmatch_ora_states.
-  Admitted.
+  Qed.
 
   (*This is a technical lemma about the interpretation of the specific  *)
   (*     program [mult_weights t nx].*)

--- a/weightslang.v
+++ b/weightslang.v
@@ -1570,8 +1570,8 @@ Section mult_weights_refinement.
     rewrite /mult_weights1_init.
     have Hx: [ffun => Q_to_rat (D_to_Q D1)] = [ffun => 1%:R].
     { move => t; rewrite /D1 /D_to_Q /Q_to_rat /= fracqE /=.
-      apply/ffunP => x; rewrite ffunE.
-      admit. }
+      apply/ffunP => x; rewrite !ffunE.
+      by rewrite GRing.divff. }
     move: (init_weights_gt0 (A:=A)) pf0 H0 H3 H6 H.
     rewrite Hx => pfx pf0 H0 H3 H6 H.
     f_equal.
@@ -1579,7 +1579,7 @@ Section mult_weights_refinement.
     f_equal.
     f_equal.
     apply: proof_irrelevance.
-  Admitted.
+  Qed.
   
   Lemma stepN_mult_weights_refines_mult_weights1 :
     forall n nx (s s' : state A) l pf,

--- a/weightslang.v
+++ b/weightslang.v
@@ -8,13 +8,13 @@ Require Import mathcomp.ssreflect.ssreflect.
 From mathcomp Require Import all_ssreflect.
 From mathcomp Require Import all_algebra.
 
-Require Import dist weights numerics bigops.
+Require Import dist weights numerics dyadic bigops.
 
 (** An extremely simple probabilistic programming language, 
     used to implement multiplicative weights update (weights.v) *)
 
 Inductive val : Type :=
-| QVal : Q -> val.
+| QVal : D -> val.
 
 Inductive binop : Type := BPlus | BMinus | BMult.
 
@@ -49,14 +49,7 @@ Arguments CIter [A] _ _.
 Lemma val_eq_dec (v1 v2 : val) : {v1=v2}+{v1<>v2}.
 Proof.
   decide equality.
-  case: q; case: q0 => x y x' y'.
-  case: (positive_eq_dec y y').
-  { move => ->.
-    case: (Z_eq_dec x x').
-    { move => ->.
-      by left. }
-    move => H; right => H2; inversion H2; subst => //. }
-  by move => H; right; inversion 1; subst.
+  apply Deq_dec.
 Qed.    
 
 Lemma eqType_eq_dec (A : eqType) (a s : A) : {a=s}+{a<>s}.
@@ -96,13 +89,13 @@ Definition mult_weights_body (A : Type) : com A :=
                       (EBinop BMult
                               (EWeight a)
                               (EBinop BMinus
-                                      (EVal (QVal 1))
+                                      (EVal (QVal D1))
                                       (EBinop BMult EEps (ECost a))))))
           CSend).
 
 Definition mult_weights_init (A : Type) : com A :=
   CSeq
-    (CUpdate (fun a : A => EVal (QVal 1)))
+    (CUpdate (fun a : A => EVal (QVal D1)))
     CSend.
 
 Definition mult_weights (A : Type) (n : N.t) : com A :=
@@ -159,7 +152,7 @@ Section semantics.
     match e with
     | EVal v =>
       match v with
-      | QVal q => Q_to_rat q
+      | QVal q => Q_to_rat (D_to_Q q)
       end
     | EOpp e' => let: v := eval e' s in - v
     | EWeight a => SWeights s a
@@ -1573,13 +1566,20 @@ Section mult_weights_refinement.
     inversion H6; subst.
     inversion H3; subst.
     simpl in *.
-    exists ch, t'.    
-    rewrite /mult_weights1_init; f_equal.
+    exists ch, t'.
+    rewrite /mult_weights1_init.
+    have Hx: [ffun => Q_to_rat (D_to_Q D1)] = [ffun => 1%:R].
+    { move => t; rewrite /D1 /D_to_Q /Q_to_rat /= fracqE /=.
+      apply/ffunP => x; rewrite ffunE.
+      admit. }
+    move: (init_weights_gt0 (A:=A)) pf0 H0 H3 H6 H.
+    rewrite Hx => pfx pf0 H0 H3 H6 H.
+    f_equal.
     apply: proof_irrelevance.
     f_equal.
     f_equal.
     apply: proof_irrelevance.
-  Qed.
+  Admitted.
   
   Lemma stepN_mult_weights_refines_mult_weights1 :
     forall n nx (s s' : state A) l pf,


### PR DESCRIPTION
Update server and MWU client to use dyadic rationals (numbers r of the form n / 2^d). This change results in speedups of: 

- loadbalancing.v: 7.4x (e=1/4, #clients=6, #iters=60, #rounds=10)
- routing1.v: 2.9x (e=1/4, #clients=15, #iters=40, #rounds=10)
- routing.v:  time w/ dyadic: 1m15s; time w/o dyadic: timeout at 17m (e=1/4, #clients=10, #iters=40, #rounds=2)